### PR TITLE
Extend driver to 6 axis

### DIFF
--- a/Src/driver.c
+++ b/Src/driver.c
@@ -161,7 +161,16 @@ static uint32_t step_outmap[sizeof(c_step_outmap) / sizeof(uint32_t)];
     #define Y_STEP_PORT STEP_PORT
   #endif
   #ifndef Z_STEP_PORT
-    #define X_STEP_PORT STEP_PORT
+    #define Z_STEP_PORT STEP_PORT
+  #endif
+  #ifndef A_STEP_PORT
+    #define A_STEP_PORT STEP_PORT
+  #endif
+  #ifndef B_STEP_PORT
+    #define B_STEP_PORT STEP_PORT
+  #endif
+  #ifndef C_STEP_PORT
+    #define C_STEP_PORT STEP_PORT
   #endif
 #endif
 
@@ -222,6 +231,12 @@ static uint32_t dir_outmap[sizeof(c_dir_outmap) / sizeof(uint32_t)];
 #ifndef A_LIMIT_PORT
   #define A_LIMIT_PORT LIMIT_PORT
 #endif
+#ifndef B_LIMIT_PORT
+  #define B_LIMIT_PORT LIMIT_PORT
+#endif
+#ifndef C_LIMIT_PORT
+  #define C_LIMIT_PORT LIMIT_PORT
+#endif
 
 #if KEYPAD_ENABLE == 0
 #define KEYPAD_STROBE_BIT 0
@@ -264,6 +279,12 @@ static void stepperEnable (axes_signals_t enable)
    #if N_AXIS > 3
     BITBAND_PERI(A_STEPPERS_DISABLE_PORT->ODR, A_STEPPERS_DISABLE_PIN) = enable.a;
    #endif
+   #if N_AXIS > 4
+    BITBAND_PERI(B_STEPPERS_DISABLE_PORT->ODR, B_STEPPERS_DISABLE_PIN) = enable.a;
+   #endif
+   #if N_AXIS > 4
+    BITBAND_PERI(C_STEPPERS_DISABLE_PORT->ODR, C_STEPPERS_DISABLE_PIN) = enable.a;
+   #endif
   #endif
 #endif
 }
@@ -301,6 +322,9 @@ inline static __attribute__((always_inline)) void stepperSetStepOutputs (axes_si
     BITBAND_PERI(X_STEP_PORT->ODR, X_STEP_PIN) = step_outbits.x;
     BITBAND_PERI(Y_STEP_PORT->ODR, Y_STEP_PIN) = step_outbits.y;
     BITBAND_PERI(Z_STEP_PORT->ODR, Z_STEP_PIN) = step_outbits.z;
+    BITBAND_PERI(A_STEP_PORT->ODR, A_STEP_PIN) = step_outbits.a;
+    BITBAND_PERI(B_STEP_PORT->ODR, B_STEP_PIN) = step_outbits.b;
+    BITBAND_PERI(C_STEP_PORT->ODR, C_STEP_PIN) = step_outbits.c;
 #elif STEP_OUTMODE == GPIO_MAP
 	STEP_PORT->ODR = (STEP_PORT->ODR & ~STEP_MASK) | step_outmap[step_outbits.value];
 #else
@@ -317,6 +341,9 @@ inline static __attribute__((always_inline)) void stepperSetDirOutputs (axes_sig
     BITBAND_PERI(X_DIRECTION_PORT->ODR, X_DIRECTION_PIN) = dir_outbits.x;
     BITBAND_PERI(Y_DIRECTION_PORT->ODR, Y_DIRECTION_PIN) = dir_outbits.y;
     BITBAND_PERI(Z_DIRECTION_PORT->ODR, Z_DIRECTION_PIN) = dir_outbits.z;
+    BITBAND_PERI(A_DIRECTION_PORT->ODR, A_DIRECTION_PIN) = dir_outbits.a;
+    BITBAND_PERI(B_DIRECTION_PORT->ODR, B_DIRECTION_PIN) = dir_outbits.b;
+    BITBAND_PERI(C_DIRECTION_PORT->ODR, C_DIRECTION_PIN) = dir_outbits.c;
 #elif DIRECTION_OUTMODE == GPIO_MAP
     DIRECTION_PORT->ODR = (DIRECTION_PORT->ODR & ~DIRECTION_MASK) | dir_outmap[dir_outbits.value];
 #else
@@ -499,6 +526,12 @@ inline static limit_signals_t limitsGetState()
   #ifdef A_LIMIT_PIN
     signals.min.a = BITBAND_PERI(A_LIMIT_PORT->IDR, A_LIMIT_PIN);
   #endif
+  #ifdef B_LIMIT_PIN
+    signals.min.b = BITBAND_PERI(B_LIMIT_PORT->IDR, B_LIMIT_PIN);
+  #endif
+  #ifdef C_LIMIT_PIN
+    signals.min.c = BITBAND_PERI(C_LIMIT_PORT->IDR, C_LIMIT_PIN);
+  #endif
 #elif LIMIT_INMODE == GPIO_MAP
     uint32_t bits = LIMIT_PORT->IDR;
     signals.min.x = (bits & X_LIMIT_BIT) != 0;
@@ -506,6 +539,12 @@ inline static limit_signals_t limitsGetState()
     signals.min.z = (bits & Z_LIMIT_BIT) != 0;
   #ifdef A_LIMIT_PIN
     signals.min.a = (bits & A_LIMIT_BIT) != 0;
+  #endif
+  #ifdef B_LIMIT_PIN
+    signals.min.b = (bits & B_LIMIT_BIT) != 0;
+  #endif
+  #ifdef C_LIMIT_PIN
+    signals.min.c = (bits & C_LIMIT_BIT) != 0;
   #endif
 #else
     signals.min.value = (uint8_t)((LIMIT_PORT->IDR & LIMIT_MASK) >> LIMIT_INMODE);
@@ -527,14 +566,14 @@ static control_signals_t systemGetState (void)
 
 #if CONTROL_INMODE == GPIO_BITBAND
 #if ESTOP_ENABLE
-    signals.e_stop = BITBAND_PERI(CONTROL_PORT->IDR, CONTROL_RESET_PIN);
+    signals.e_stop = BITBAND_PERI(CONTROL_RESET_PORT->IDR, CONTROL_RESET_PIN);
 #else
-    signals.reset = BITBAND_PERI(CONTROL_PORT->IDR, CONTROL_RESET_PIN);
+    signals.reset = BITBAND_PERI(CONTROL_RESET_PORT->IDR, CONTROL_RESET_PIN);
 #endif
-    signals.feed_hold = BITBAND_PERI(CONTROL_PORT->IDR, CONTROL_FEED_HOLD_PIN);
-    signals.cycle_start = BITBAND_PERI(CONTROL_PORT->IDR, CONTROL_CYCLE_START_PIN);
+    signals.feed_hold = BITBAND_PERI(CONTROL_FEED_HOLD_PORT->IDR, CONTROL_FEED_HOLD_PIN);
+    signals.cycle_start = BITBAND_PERI(CONTROL_CYCLE_START_PORT->IDR, CONTROL_CYCLE_START_PIN);
   #ifdef CONTROL_SAFETY_DOOR_PIN
-    signals.safety_door_ajar = BITBAND_PERI(CONTROL_PORT->IDR, CONTROL_SAFETY_DOOR_PIN);
+    signals.safety_door_ajar = BITBAND_PERI(CONTROL_SAFETY_DOOR_PORT->IDR, CONTROL_SAFETY_DOOR_PIN);
   #endif
 #elif CONTROL_INMODE == GPIO_MAP
     uint32_t bits = CONTROL_PORT->IDR;
@@ -1021,26 +1060,41 @@ void settings_changed (settings_t *settings)
         HAL_NVIC_DisableIRQ(EXTI15_10_IRQn);
 #endif
 
+#ifdef CONTROL_PORT
+  #ifndef CONTROL_RESET_PORT
+    #define CONTROL_RESET_PORT CONTROL_PORT
+  #endif
+  #ifndef CONTROL_FEED_HOLD_PORT
+    #define CONTROL_FEED_HOLD_PORT CONTROL_PORT
+  #endif
+  #ifndef CONTROL_CYCLE_START_PORT
+    #define CONTROL_CYCLE_START_PORT CONTROL_PORT
+  #endif
+  #ifndef CONTROL_SAFETY_DOOR_PORT
+    #define CONTROL_SAFETY_DOOR_PORT CONTROL_PORT
+  #endif
+#endif
+
         GPIO_Init.Pin = CONTROL_RESET_BIT;
         GPIO_Init.Mode = control_ire.reset ? GPIO_MODE_IT_RISING : GPIO_MODE_IT_FALLING;
         GPIO_Init.Pull = settings->control_disable_pullup.reset ? GPIO_NOPULL : GPIO_PULLUP;
-        HAL_GPIO_Init(CONTROL_PORT, &GPIO_Init);
+        HAL_GPIO_Init(CONTROL_RESET_PORT, &GPIO_Init);
 
         GPIO_Init.Pin = CONTROL_FEED_HOLD_BIT;
         GPIO_Init.Mode = control_ire.feed_hold ? GPIO_MODE_IT_RISING : GPIO_MODE_IT_FALLING;
         GPIO_Init.Pull = settings->control_disable_pullup.feed_hold ? GPIO_NOPULL : GPIO_PULLUP;
-        HAL_GPIO_Init(CONTROL_PORT, &GPIO_Init);
+        HAL_GPIO_Init(CONTROL_FEED_HOLD_PORT, &GPIO_Init);
 
         GPIO_Init.Pin = CONTROL_CYCLE_START_BIT;
         GPIO_Init.Mode = control_ire.cycle_start ? GPIO_MODE_IT_RISING : GPIO_MODE_IT_FALLING;
         GPIO_Init.Pull = settings->control_disable_pullup.cycle_start ? GPIO_NOPULL : GPIO_PULLUP;
-        HAL_GPIO_Init(CONTROL_PORT, &GPIO_Init);
+        HAL_GPIO_Init(CONTROL_CYCLE_START_PORT, &GPIO_Init);
 
 #ifdef CONTROL_SAFETY_DOOR_PIN
         GPIO_Init.Pin = CONTROL_SAFETY_DOOR_BIT;
         GPIO_Init.Mode = control_ire.safety_door_ajar ? GPIO_MODE_IT_RISING : GPIO_MODE_IT_FALLING;
         GPIO_Init.Pull = settings->control_disable_pullup.safety_door_ajar ? GPIO_NOPULL : GPIO_PULLUP;
-        HAL_GPIO_Init(CONTROL_PORT, &GPIO_Init);
+        HAL_GPIO_Init(CONTROL_SAFETY_DOOR_PORT, &GPIO_Init);
 #endif
 
         /***********************
@@ -1074,13 +1128,19 @@ void settings_changed (settings_t *settings)
             GPIO_Init.Pin = A_LIMIT_BIT;
             GPIO_Init.Mode = limit_ire.a ? GPIO_MODE_IT_RISING : GPIO_MODE_IT_FALLING;
             GPIO_Init.Pull = settings->limits.disable_pullup.a ? GPIO_NOPULL : GPIO_PULLUP;
-            HAL_GPIO_Init(LIMIT_PORT, &GPIO_Init);
+            HAL_GPIO_Init(A_LIMIT_PORT, &GPIO_Init);
 #endif
 #ifdef B_LIMIT_BIT
             GPIO_Init.Pin = B_LIMIT_BIT;
             GPIO_Init.Mode = limit_ire.b ? GPIO_MODE_IT_RISING : GPIO_MODE_IT_FALLING;
             GPIO_Init.Pull = settings->limits.disable_pullup.b ? GPIO_NOPULL : GPIO_PULLUP;
-            HAL_GPIO_Init(LIMIT_PORT, &GPIO_Init);
+            HAL_GPIO_Init(B_LIMIT_PORT, &GPIO_Init);
+#endif
+#ifdef C_LIMIT_BIT
+            GPIO_Init.Pin = C_LIMIT_BIT;
+            GPIO_Init.Mode = limit_ire.c ? GPIO_MODE_IT_RISING : GPIO_MODE_IT_FALLING;
+            GPIO_Init.Pull = settings->limits.disable_pullup.c ? GPIO_NOPULL : GPIO_PULLUP;
+            HAL_GPIO_Init(C_LIMIT_PORT, &GPIO_Init);
 #endif
 
         } else {
@@ -1103,12 +1163,17 @@ void settings_changed (settings_t *settings)
 #ifdef A_LIMIT_BIT
             GPIO_Init.Pin = A_LIMIT_BIT;
             GPIO_Init.Pull = settings->limits.disable_pullup.a ? GPIO_NOPULL : GPIO_PULLUP;
-            HAL_GPIO_Init(LIMIT_PORT, &GPIO_Init);
+            HAL_GPIO_Init(A_LIMIT_PORT, &GPIO_Init);
 #endif
 #ifdef B_LIMIT_BIT
             GPIO_Init.Pin = B_LIMIT_BIT;
             GPIO_Init.Pull = settings->limits.disable_pullup.b ? GPIO_NOPULL : GPIO_PULLUP;
-            HAL_GPIO_Init(LIMIT_PORT, &GPIO_Init);
+            HAL_GPIO_Init(B_LIMIT_PORT, &GPIO_Init);
+#endif
+#ifdef C_LIMIT_BIT
+            GPIO_Init.Pin = C_LIMIT_BIT;
+            GPIO_Init.Pull = settings->limits.disable_pullup.c ? GPIO_NOPULL : GPIO_PULLUP;
+            HAL_GPIO_Init(C_LIMIT_PORT, &GPIO_Init);
 #endif
         }
 
@@ -1199,10 +1264,19 @@ static bool driver_setup (settings_t *settings)
     HAL_GPIO_Init(Y_STEPPERS_DISABLE_PORT, &GPIO_Init);
     GPIO_Init.Pin = Z_STEPPERS_DISABLE_BIT;
     HAL_GPIO_Init(Z_STEPPERS_DISABLE_PORT, &GPIO_Init);
- #if N_AXIS > 3
-  GPIO_Init.Pin = A_STEPPERS_DISABLE_BIT;
-  HAL_GPIO_Init(A_STEPPERS_DISABLE_PORT, &GPIO_Init);
- #endif
+  #if N_AXIS > 3
+    GPIO_Init.Pin = A_STEPPERS_DISABLE_BIT;
+    HAL_GPIO_Init(A_STEPPERS_DISABLE_PORT, &GPIO_Init);
+  #endif
+  #if N_AXIS > 4
+    GPIO_Init.Pin = B_STEPPERS_DISABLE_BIT;
+    HAL_GPIO_Init(B_STEPPERS_DISABLE_PORT, &GPIO_Init);
+   #endif
+  #if N_AXIS > 5
+    GPIO_Init.Pin = C_STEPPERS_DISABLE_BIT;
+    HAL_GPIO_Init(C_STEPPERS_DISABLE_PORT, &GPIO_Init);
+  #endif
+
 #endif
 
 #ifdef STEP_MASK
@@ -1215,6 +1289,18 @@ static bool driver_setup (settings_t *settings)
     HAL_GPIO_Init(Y_STEP_PORT, &GPIO_Init);
     GPIO_Init.Pin = Z_STEP_BIT;
     HAL_GPIO_Init(Z_STEP_PORT, &GPIO_Init);
+  #if N_AXIS > 3
+    GPIO_Init.Pin = A_STEP_BIT;
+    HAL_GPIO_Init(A_STEP_PORT, &GPIO_Init);
+  #endif
+  #if N_AXIS > 4
+    GPIO_Init.Pin = B_STEP_BIT;
+    HAL_GPIO_Init(B_STEP_PORT, &GPIO_Init);
+   #endif
+  #if N_AXIS > 5
+    GPIO_Init.Pin = C_STEP_BIT;
+    HAL_GPIO_Init(C_STEP_PORT, &GPIO_Init);
+  #endif
 #endif
 
 #ifdef DIRECTION_MASK
@@ -1227,6 +1313,18 @@ static bool driver_setup (settings_t *settings)
     HAL_GPIO_Init(Y_DIRECTION_PORT, &GPIO_Init);
     GPIO_Init.Pin = Z_DIRECTION_BIT;
     HAL_GPIO_Init(Z_DIRECTION_PORT, &GPIO_Init);
+  #if N_AXIS > 3
+    GPIO_Init.Pin = A_DIRECTION_BIT;
+    HAL_GPIO_Init(A_DIRECTION_PORT, &GPIO_Init);
+  #endif
+  #if N_AXIS > 4
+    GPIO_Init.Pin = B_DIRECTION_BIT;
+    HAL_GPIO_Init(B_DIRECTION_PORT, &GPIO_Init);
+   #endif
+  #if N_AXIS > 5
+    GPIO_Init.Pin = C_DIRECTION_BIT;
+    HAL_GPIO_Init(C_DIRECTION_PORT, &GPIO_Init);
+  #endif
 #endif
 
     STEPPER_TIMER->CR1 &= ~TIM_CR1_CEN;

--- a/Src/main.c
+++ b/Src/main.c
@@ -186,6 +186,11 @@ static void MX_GPIO_Init(void)
   __HAL_RCC_GPIOB_CLK_ENABLE();
   __HAL_RCC_GPIOA_CLK_ENABLE();
   __HAL_RCC_GPIOD_CLK_ENABLE();
+  __HAL_RCC_GPIOE_CLK_ENABLE();
+#if defined (STM32F407xx) || defined (STM32F446xx)
+  __HAL_RCC_GPIOF_CLK_ENABLE();
+  __HAL_RCC_GPIOG_CLK_ENABLE();
+#endif
 }
 
 /**


### PR DESCRIPTION
This PR extends STM32F4xx driver to fully support 6-axis configurations.

I also added an option to specify control signals using different PORT and PIN combinations as it was needed for my application.

Driver was tested on real hardware using STM32F407 config and everything seems to be working but there is always a chance I messed something up, so please give me your thoughts.

br,
Mario