### PR TITLE
Reworked board_init() per style used for LP176x.

### DIFF
--- a/Inc/btt_skr_2.0_map.h
+++ b/Inc/btt_skr_2.0_map.h
@@ -37,6 +37,11 @@
 #define I2C_PORT 1      // GPIOB, SCL_PIN = 8, SDA_PIN = 9
 //#define I2C1_ALT_PINMAP // GPIOB, SCL_PIN = 6, SDA_PIN = 7
 
+// If we want to debug, we need to use USART1
+#if defined(DEBUG) && defined(USB_SERIAL_CDC)
+#undef USB_SERIAL_CDC
+#endif
+
 // Define step pulse output pins.
 #define X_STEP_PORT                 GPIOE
 #define X_STEP_PIN                  2                   // X
@@ -170,43 +175,49 @@
 
 // The BTT SKR-2 uses software SPI
 // MISO pin is also SWCLK from JTAG port, so can't debug with Trinamic SPI drivers:-(
-#define TMC_MOSI_PORT               GPIOE
-#define TMC_MOSI_PIN                14
-#define TMC_MOSI_BIT                (1 << TMC_MOSI_PIN)
-#define TMC_SCK_PORT                GPIOE
-#define TMC_SCK_PIN                 15
-#define TMC_SCK_BIT                 (1 << TMC_SCK_PIN)
-#define TMC_MISO_PORT               GPIOA
+#define TRINAMIC_MOSI_PORT          GPIOE
+#define TRINAMIC_MOSI_PIN           14
+#define TRINAMIC_MOSI_BIT           (1 << TRINAMIC_MOSI_PIN)
+#define TRINAMIC_SCK_PORT           GPIOE
+#define TRINAMIC_SCK_PIN            15
+#define TRINAMIC_SCK_BIT            (1 << TRINAMIC_SCK_PIN)
+#define TRINAMIC_MISO_PORT          GPIOA
 
 // BigTreeTech used PA14 (SWCLK) as MOT_MISO.
 // For debugging, change this to PA6 (on EXP2) and jumper directly to MISO pins on TMC2130s.
 #ifdef DEBUG
-#define TMC_MISO_PIN                6		// temporary EXP2-1 to use while debugging.  real one is PA14
+#define TRINAMIC_MISO_PIN           6		// temporary EXP2-1 to use while debugging.  real one is PA14
 #else
-#define TMC_MISO_PIN                14
+#define TRINAMIC_MISO_PIN           14
 #endif
-#define TMC_MISO_BIT                (1 << TMC_MISO_PIN)
+#define TRINAMIC_MISO_BIT           (1 << TRINAMIC_MISO_PIN)
 
 // The CS pins are also the UART pins for 1 wire serial Trinamic drivers (2208, 2209)
-#define TMC_CSX_PORT                GPIOE
-#define TMC_CSX_PIN                 0
-#define TMC_CSX_BIT                 (1 << TMC_CSX_PIN)
-#define TMC_CSY_PORT                GPIOD
-#define TMC_CSY_PIN                 3
-#define TMC_CSY_BIT                 (1 << TMC_CSY_PIN)
-#define TMC_CSZ_PORT                GPIOD
-#define TMC_CSZ_PIN                 0
-#define TMC_CSZ_BIT                 (1 << TMC_CSZ_PIN)
-#define TMC_CSA_PORT                GPIOC
-#define TMC_CSA_PIN                 6
-#define TMC_CSA_BIT                 (1 << TMC_CSA_PIN)
-#define TMC_CSB_PORT                GPIOD
-#define TMC_CSB_PIN                 12
-#define TMC_CSB_BIT                 (1 << TMC_CSB_PIN)
+#define MOTOR_CSX_PORT              GPIOE
+#define MOTOR_CSX_PIN               0
+#define MOTOR_CSX_BIT               (1 << MOTOR_CSX_PIN)
+#define MOTOR_CSY_PORT              GPIOD
+#define MOTOR_CSY_PIN               3
+#define MOTOR_CSY_BIT               (1 << MOTOR_CSY_PIN)
+#define MOTOR_CSZ_PORT              GPIOD
+#define MOTOR_CSZ_PIN               0
+#define MOTOR_CSZ_BIT               (1 << MOTOR_CSZ_PIN)
+
+#ifdef  M3_AVAILABLE
+#define MOTOR_CSM3_PORT             GPIOC
+#define MOTOR_CSM3_PIN              6
+#define MOTOR_CSM3_BIT              (1 << MOTOR_CSM3_PIN)
+#endif
+
+#ifdef  M4_AVAILABLE
+#define MOTOR_CSM4_PORT             GPIOD
+#define MOTOR_CSM4_PIN              12
+#define MOTOR_CSM4_BIT              (1 << MOTOR_CSM4_PIN)
+#endif
 
 // Safe Power Control
-#define SAFE_PWR_PORT               GPIOC
-#define SAFE_PWR_PIN                13
-#define SAFE_PWR_BIT                (1 << SAFE_PWR_PIN)
+#define STEPPERS_POWER_PORT         GPIOC
+#define STEPPERS_POWER_PIN          13
+#define STEPPERS_POWER_BIT          (1 << STEPPERS_POWER_PIN)
 
 // EOF

--- a/Inc/driver.h
+++ b/Inc/driver.h
@@ -43,7 +43,7 @@
 #define BITBAND_PERI(x, b) (*((__IO uint8_t *) (PERIPH_BB_BASE + (((uint32_t)(volatile const uint32_t *)&(x)) - PERIPH_BASE)*32 + (b)*4)))
 
 #define DIGITAL_IN(port, pin) BITBAND_PERI(port->IDR, pin)
-#define DIGITAL_OUT(port, pin, on) { BITBAND_PERI(port->ODR, pin) = on; }
+#define DIGITAL_OUT(port, pin, on) { BITBAND_PERI((port)->ODR, pin) = on; }
 
 #define timer(p) timerN(p)
 #define timerN(p) TIM ## p

--- a/Src/btt_skr_2.0.c
+++ b/Src/btt_skr_2.0.c
@@ -30,8 +30,13 @@
 #define spi_get_byte() sw_spi_xfer(0)
 #define spi_put_byte(d) sw_spi_xfer(d)
 
-static uint16_t cs_bit[N_AXIS];
+static uint16_t cs_pin[N_AXIS];
 static GPIO_TypeDef *cs_port[N_AXIS];
+
+static struct {
+    GPIO_TypeDef *port;
+    uint16_t bit;
+} cs[TMC_N_MOTORS_MAX];
 
 // XXXXX replace with something better...
 inline static void delay (void)
@@ -46,17 +51,17 @@ static uint8_t sw_spi_xfer (uint8_t byte)
 {
     uint_fast8_t msk = 0x80, res = 0;
 
-    DIGITAL_OUT(TMC_SCK_PORT, TMC_SCK_PIN, 0);
+    DIGITAL_OUT(TRINAMIC_SCK_PORT, TRINAMIC_SCK_PIN, 0);
 
     do {
-        DIGITAL_OUT(TMC_MOSI_PORT, TMC_MOSI_PIN, (byte & msk) != 0);
+        DIGITAL_OUT(TRINAMIC_MOSI_PORT, TRINAMIC_MOSI_PIN, (byte & msk) != 0);
         msk >>= 1;
         delay();
-        res = (res << 1) | DIGITAL_IN(TMC_MISO_PORT, TMC_MISO_PIN);
-        DIGITAL_OUT(TMC_SCK_PORT, TMC_SCK_PIN, 1);
+        res = (res << 1) | DIGITAL_IN(TRINAMIC_MISO_PORT, TRINAMIC_MISO_PIN);
+        DIGITAL_OUT(TRINAMIC_SCK_PORT, TRINAMIC_SCK_PIN, 1);
         delay();
         if(msk)
-            DIGITAL_OUT(TMC_SCK_PORT, TMC_SCK_PIN, 0);
+            DIGITAL_OUT(TRINAMIC_SCK_PORT, TRINAMIC_SCK_PIN, 0);
     } while (msk);
 
     return (uint8_t)res;
@@ -66,7 +71,7 @@ TMC_spi_status_t tmc_spi_read (trinamic_motor_t driver, TMC_spi_datagram_t *data
 {
     TMC_spi_status_t status;
 
-    HAL_GPIO_WritePin(cs_port[driver.axis], cs_bit[driver.axis], GPIO_PIN_RESET);
+    DIGITAL_OUT(cs_port[driver.axis], cs_pin[driver.axis], 0);
 
     datagram->payload.value = 0;
 
@@ -77,9 +82,9 @@ TMC_spi_status_t tmc_spi_read (trinamic_motor_t driver, TMC_spi_datagram_t *data
     spi_put_byte(0);
     spi_put_byte(0);
 
-    HAL_GPIO_WritePin(cs_port[driver.axis], cs_bit[driver.axis], GPIO_PIN_SET);
+    DIGITAL_OUT(cs_port[driver.axis], cs_pin[driver.axis], 1);
     delay();
-    HAL_GPIO_WritePin(cs_port[driver.axis], cs_bit[driver.axis], GPIO_PIN_RESET);
+    DIGITAL_OUT(cs_port[driver.axis], cs_pin[driver.axis], 0);
 
     status = spi_put_byte(datagram->addr.value);
     datagram->payload.data[3] = spi_get_byte();
@@ -87,7 +92,7 @@ TMC_spi_status_t tmc_spi_read (trinamic_motor_t driver, TMC_spi_datagram_t *data
     datagram->payload.data[1] = spi_get_byte();
     datagram->payload.data[0] = spi_get_byte();
 
-    HAL_GPIO_WritePin(cs_port[driver.axis], cs_bit[driver.axis], GPIO_PIN_SET);
+    DIGITAL_OUT(cs_port[driver.axis], cs_pin[driver.axis], 1);
 
     return status;
 }
@@ -96,7 +101,7 @@ TMC_spi_status_t tmc_spi_write (trinamic_motor_t driver, TMC_spi_datagram_t *dat
 {
     TMC_spi_status_t status;
 
-    HAL_GPIO_WritePin(cs_port[driver.axis], cs_bit[driver.axis], GPIO_PIN_RESET);
+    DIGITAL_OUT(cs_port[driver.axis], cs_pin[driver.axis], 0);
 
     datagram->addr.write = 1;
     status = spi_put_byte(datagram->addr.value);
@@ -105,92 +110,141 @@ TMC_spi_status_t tmc_spi_write (trinamic_motor_t driver, TMC_spi_datagram_t *dat
     spi_put_byte(datagram->payload.data[1]);
     spi_put_byte(datagram->payload.data[0]);
 
-    HAL_GPIO_WritePin(cs_port[driver.axis], cs_bit[driver.axis], GPIO_PIN_SET);
+    DIGITAL_OUT(cs_port[driver.axis], cs_pin[driver.axis], 1);
 
     return status;
 }
 
 #endif
 
+static void add_cs_pin (xbar_t *pin)
+{
+    if(pin->group == PinGroup_MotorChipSelect) {
+        switch(pin->function) {
+
+            case Output_MotorChipSelectX:
+                cs[X_AXIS].bit = pin->bit;
+                cs[X_AXIS].port = (GPIO_TypeDef *)pin->port;
+                break;
+            case Output_MotorChipSelectY:
+                cs[Y_AXIS].bit = pin->bit;
+                cs[Y_AXIS].port = (GPIO_TypeDef *)pin->port;
+                break;
+            case Output_MotorChipSelectZ:
+                cs[Z_AXIS].bit = pin->bit;
+                cs[Z_AXIS].port = (GPIO_TypeDef *)pin->port;
+                break;
+            case Output_MotorChipSelectM3:
+                cs[3].bit = pin->bit;
+                cs[3].port = (GPIO_TypeDef *)pin->port;
+                break;
+            case Output_MotorChipSelectM4:
+                cs[4].bit = pin->bit;
+                cs[5].port = (GPIO_TypeDef *)pin->port;
+                break;
+
+            default:
+                break;
+        }
+    }
+
+    if(pin->group == PinGroup_StepperPower) {
+		if(pin->function == Output_StepperPower) {
+			DIGITAL_OUT((GPIO_TypeDef *)(pin->port), pin->pin, 1);
+			HAL_Delay(100);
+		}
+    }
+}
+
 #if TRINAMIC_ENABLE == 2209
 #endif
 
+static void if_init(axes_signals_t enabled)
+{
+    static bool init_ok = false;
+
+    if(!init_ok) {
+        GPIO_InitTypeDef GPIO_InitStruct = {0};
+
+        // Set all output pins: push-pull, no pull-up, slow
+        GPIO_InitStruct.Pin = TRINAMIC_MOSI_BIT;
+        GPIO_InitStruct.Mode = GPIO_MODE_OUTPUT_PP;
+        GPIO_InitStruct.Pull = GPIO_NOPULL;
+        GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_LOW;
+        HAL_GPIO_Init(TRINAMIC_MOSI_PORT, &GPIO_InitStruct);
+
+        GPIO_InitStruct.Pin = TRINAMIC_SCK_BIT;
+        HAL_GPIO_Init(TRINAMIC_SCK_PORT, &GPIO_InitStruct);
+        DIGITAL_OUT(TRINAMIC_SCK_PORT, TRINAMIC_SCK_PIN, 1);
+
+        GPIO_InitStruct.Pin = MOTOR_CSX_BIT;
+        HAL_GPIO_Init(MOTOR_CSX_PORT, &GPIO_InitStruct);
+        DIGITAL_OUT(MOTOR_CSX_PORT, MOTOR_CSX_PIN, 1);
+
+        GPIO_InitStruct.Pin = MOTOR_CSY_BIT;
+        HAL_GPIO_Init(MOTOR_CSY_PORT, &GPIO_InitStruct);
+        DIGITAL_OUT(MOTOR_CSY_PORT, MOTOR_CSY_PIN, 1);
+
+        GPIO_InitStruct.Pin = MOTOR_CSZ_BIT;
+        HAL_GPIO_Init(MOTOR_CSZ_PORT, &GPIO_InitStruct);
+        DIGITAL_OUT(MOTOR_CSZ_PORT, MOTOR_CSZ_PIN, 1);
+
+#ifdef A_AXIS
+        GPIO_InitStruct.Pin = MOTOR_CSM3_BIT;
+        HAL_GPIO_Init(MOTOR_CSM3_PORT, &GPIO_InitStruct);
+        DIGITAL_OUT(MOTOR_CSM3_PORT, MOTOR_CSM3_PIN, 1);
+#endif
+
+#ifdef B_AXIS
+        GPIO_InitStruct.Pin = MOTOR_CSM4_BIT;
+        HAL_GPIO_Init(MOTOR_CSM4_PORT, &GPIO_InitStruct);
+        DIGITAL_OUT(MOTOR_CSM4_PORT, MOTOR_CSM4_PIN, 1);
+#endif
+
+        // Set the input pin: input with pull-up
+        GPIO_InitStruct.Pin = TRINAMIC_MISO_BIT;
+        GPIO_InitStruct.Mode = GPIO_MODE_INPUT;
+        GPIO_InitStruct.Pull = GPIO_PULLUP;
+        HAL_GPIO_Init(TRINAMIC_MISO_PORT, &GPIO_InitStruct);
+
+        // Save pin and port information
+        // XXXXX This may be redundant with enumerate_pins
+        cs_pin[X_AXIS] = MOTOR_CSX_PIN;
+        cs_port[X_AXIS] = MOTOR_CSX_PORT;
+        cs_pin[Y_AXIS] = MOTOR_CSY_PIN;
+        cs_port[Y_AXIS] = MOTOR_CSY_PORT;
+        cs_pin[Z_AXIS] = MOTOR_CSZ_PIN;
+        cs_port[Z_AXIS] = MOTOR_CSZ_PORT;
+#ifdef A_AXIS
+        cs_pin[A_AXIS] = MOTOR_CSM3_PIN;
+        cs_port[A_AXIS] = MOTOR_CSM3_PORT;
+#endif
+#ifdef B_AXIS
+        cs_bit[B_AXIS] = MOTOR_CSM4_PIN;
+        cs_port[B_AXIS] = MOTOR_CSM4_PORT;
+#endif
+
+        hal.enumerate_pins(true, add_cs_pin);
+    }
+}
+
 void board_init (void)
 {
-    GPIO_InitTypeDef GPIO_InitStruct = {0};
 
 #if TRINAMIC_ENABLE == 2130 || TRINAMIC_ENABLE == 5160
 
-    // Set all output pins: push-pull, no pull-up, slow
-    GPIO_InitStruct.Pin = TMC_MOSI_BIT;
-    GPIO_InitStruct.Mode = GPIO_MODE_OUTPUT_PP;
-    GPIO_InitStruct.Pull = GPIO_NOPULL;
-    GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_LOW;
-    HAL_GPIO_Init(TMC_MOSI_PORT, &GPIO_InitStruct);
+    static trinamic_driver_if_t driver_if = {
+        .on_drivers_init = if_init
+    };
 
-    GPIO_InitStruct.Pin = TMC_SCK_BIT;
-    HAL_GPIO_Init(TMC_SCK_PORT, &GPIO_InitStruct);
-    HAL_GPIO_WritePin(TMC_SCK_PORT, TMC_SCK_BIT, GPIO_PIN_SET);
+    trinamic_if_init(&driver_if);
 
-    GPIO_InitStruct.Pin = TMC_CSX_BIT;
-    HAL_GPIO_Init(TMC_CSX_PORT, &GPIO_InitStruct);
-    HAL_GPIO_WritePin(TMC_CSX_PORT, TMC_CSX_BIT, GPIO_PIN_SET);
-
-    GPIO_InitStruct.Pin = TMC_CSY_BIT;
-    HAL_GPIO_Init(TMC_CSY_PORT, &GPIO_InitStruct);
-    HAL_GPIO_WritePin(TMC_CSY_PORT, TMC_CSY_BIT, GPIO_PIN_SET);
-
-    GPIO_InitStruct.Pin = TMC_CSZ_BIT;
-    HAL_GPIO_Init(TMC_CSZ_PORT, &GPIO_InitStruct);
-    HAL_GPIO_WritePin(TMC_CSZ_PORT, TMC_CSZ_BIT, GPIO_PIN_SET);
-
-#ifdef A_AXIS
-    GPIO_InitStruct.Pin = TMC_CSA_BIT;
-    HAL_GPIO_Init(TMC_CSA_PORT, &GPIO_InitStruct);
-    HAL_GPIO_WritePin(TMC_CSA_PORT, TMC_CSA_BIT, GPIO_PIN_SET);
-#endif
-
-#ifdef B_AXIS
-    GPIO_InitStruct.Pin = TMC_CSB_BIT;
-    HAL_GPIO_Init(TMC_CSB_PORT, &GPIO_InitStruct);
-    HAL_GPIO_WritePin(TMC_CSA_PORT, TMC_CSA_BIT, GPIO_PIN_SET);
-#endif
-
-    // Set the input pin: input with pull-up
-    GPIO_InitStruct.Pin = TMC_MISO_BIT;
-    GPIO_InitStruct.Mode = GPIO_MODE_INPUT;
-    GPIO_InitStruct.Pull = GPIO_PULLUP;
-    HAL_GPIO_Init(TMC_MISO_PORT, &GPIO_InitStruct);
-
-    // Save pin and port information
-    cs_bit[X_AXIS] = TMC_CSX_BIT;
-    cs_port[X_AXIS] = TMC_CSX_PORT;
-    cs_bit[Y_AXIS] = TMC_CSY_BIT;
-    cs_port[Y_AXIS] = TMC_CSY_PORT;
-    cs_bit[Z_AXIS] = TMC_CSZ_BIT;
-    cs_port[Z_AXIS] = TMC_CSZ_PORT;
-#ifdef A_AXIS
-    cs_bit[A_AXIS] = TMC_CSA_BIT;
-    cs_port[A_AXIS] = TMC_CSA_PORT;
-#endif
-#ifdef B_AXIS
-    cs_bit[B_AXIS] = TMC_CSB_BIT;
-    cs_port[B_AXIS] = TMC_CSB_PORT;
-#endif
 
 #endif  // TRINAMIC_ENABLE == 2130 || TRINAMIC_ENABLE == 5160
 
 #if TRINAMIC_ENABLE == 2209
 #endif  // TRINAMIC_ENABLE == 2209
 
-    // The BTT SKR-2 has "Power Protection".
-    // This GPIO pin must be driven to get any power to the steppers at all.
-    GPIO_InitStruct.Mode = GPIO_MODE_OUTPUT_PP;
-    GPIO_InitStruct.Pull = GPIO_NOPULL;
-    GPIO_InitStruct.Pin = SAFE_PWR_BIT;
-    HAL_GPIO_Init(SAFE_PWR_PORT, &GPIO_InitStruct);
-    HAL_GPIO_WritePin(SAFE_PWR_PORT, SAFE_PWR_BIT, GPIO_PIN_SET);
-    hal.delay_ms(100, NULL);	// need a little time for the power to come up and driver to come out of reset
 }
 
 #endif  // BOARD_BTT_SKR_20


### PR DESCRIPTION
Replaced all calls to HAL_GPIO_WritePin() with DIGITAL_OUT macro.
Revised btt_skr_2.0_map.h to use standardized #defines for motors 3 and 4.
Fixed DIGITAL_OUT macro in driver.h.