### PR TITLE
Add analog output (DAC) capability to BTT SKR-2 for spindle speed control

### DIFF
--- a/Drivers/STM32F4xx_HAL_Driver/Inc/stm32f4xx_hal_dac.h
+++ b/Drivers/STM32F4xx_HAL_Driver/Inc/stm32f4xx_hal_dac.h
@@ -1,0 +1,482 @@
+/**
+  ******************************************************************************
+  * @file    stm32f4xx_hal_dac.h
+  * @author  MCD Application Team
+  * @brief   Header file of DAC HAL module.
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; Copyright (c) 2016 STMicroelectronics.
+  * All rights reserved.</center></h2>
+  *
+  * This software component is licensed by ST under BSD 3-Clause license,
+  * the "License"; You may not use this file except in compliance with the
+  * License. You may obtain a copy of the License at:
+  *                        opensource.org/licenses/BSD-3-Clause
+  *
+  ******************************************************************************
+  */
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef STM32F4xx_HAL_DAC_H
+#define STM32F4xx_HAL_DAC_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/** @addtogroup STM32F4xx_HAL_Driver
+  * @{
+  */
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32f4xx_hal_def.h"
+
+#if defined(DAC)
+
+/** @addtogroup DAC
+  * @{
+  */
+
+/* Exported types ------------------------------------------------------------*/
+
+/** @defgroup DAC_Exported_Types DAC Exported Types
+  * @{
+  */
+
+/**
+  * @brief  HAL State structures definition
+  */
+typedef enum
+{
+  HAL_DAC_STATE_RESET             = 0x00U,  /*!< DAC not yet initialized or disabled  */
+  HAL_DAC_STATE_READY             = 0x01U,  /*!< DAC initialized and ready for use    */
+  HAL_DAC_STATE_BUSY              = 0x02U,  /*!< DAC internal processing is ongoing   */
+  HAL_DAC_STATE_TIMEOUT           = 0x03U,  /*!< DAC timeout state                    */
+  HAL_DAC_STATE_ERROR             = 0x04U   /*!< DAC error state                      */
+
+} HAL_DAC_StateTypeDef;
+
+/**
+  * @brief  DAC handle Structure definition
+  */
+#if (USE_HAL_DAC_REGISTER_CALLBACKS == 1)
+typedef struct __DAC_HandleTypeDef
+#else
+typedef struct
+#endif /* USE_HAL_DAC_REGISTER_CALLBACKS */
+{
+  DAC_TypeDef                 *Instance;     /*!< Register base address             */
+
+  __IO HAL_DAC_StateTypeDef   State;         /*!< DAC communication state           */
+
+  HAL_LockTypeDef             Lock;          /*!< DAC locking object                */
+
+  DMA_HandleTypeDef           *DMA_Handle1;  /*!< Pointer DMA handler for channel 1 */
+
+  DMA_HandleTypeDef           *DMA_Handle2;  /*!< Pointer DMA handler for channel 2 */
+
+  __IO uint32_t               ErrorCode;     /*!< DAC Error code                    */
+
+#if (USE_HAL_DAC_REGISTER_CALLBACKS == 1)
+  void (* ConvCpltCallbackCh1)            (struct __DAC_HandleTypeDef *hdac);
+  void (* ConvHalfCpltCallbackCh1)        (struct __DAC_HandleTypeDef *hdac);
+  void (* ErrorCallbackCh1)               (struct __DAC_HandleTypeDef *hdac);
+  void (* DMAUnderrunCallbackCh1)         (struct __DAC_HandleTypeDef *hdac);
+#if defined(DAC_CHANNEL2_SUPPORT)
+  void (* ConvCpltCallbackCh2)            (struct __DAC_HandleTypeDef *hdac);
+  void (* ConvHalfCpltCallbackCh2)        (struct __DAC_HandleTypeDef *hdac);
+  void (* ErrorCallbackCh2)               (struct __DAC_HandleTypeDef *hdac);
+  void (* DMAUnderrunCallbackCh2)         (struct __DAC_HandleTypeDef *hdac);
+#endif /* DAC_CHANNEL2_SUPPORT */
+
+  void (* MspInitCallback)                (struct __DAC_HandleTypeDef *hdac);
+  void (* MspDeInitCallback)              (struct __DAC_HandleTypeDef *hdac);
+#endif /* USE_HAL_DAC_REGISTER_CALLBACKS */
+
+} DAC_HandleTypeDef;
+
+/**
+  * @brief   DAC Configuration regular Channel structure definition
+  */
+typedef struct
+{
+  uint32_t DAC_Trigger;                  /*!< Specifies the external trigger for the selected DAC channel.
+                                              This parameter can be a value of @ref DAC_trigger_selection */
+
+  uint32_t DAC_OutputBuffer;             /*!< Specifies whether the DAC channel output buffer is enabled or disabled.
+                                               This parameter can be a value of @ref DAC_output_buffer */
+
+} DAC_ChannelConfTypeDef;
+
+#if (USE_HAL_DAC_REGISTER_CALLBACKS == 1)
+/**
+  * @brief  HAL DAC Callback ID enumeration definition
+  */
+typedef enum
+{
+  HAL_DAC_CH1_COMPLETE_CB_ID                 = 0x00U,  /*!< DAC CH1 Complete Callback ID      */
+  HAL_DAC_CH1_HALF_COMPLETE_CB_ID            = 0x01U,  /*!< DAC CH1 half Complete Callback ID */
+  HAL_DAC_CH1_ERROR_ID                       = 0x02U,  /*!< DAC CH1 error Callback ID         */
+  HAL_DAC_CH1_UNDERRUN_CB_ID                 = 0x03U,  /*!< DAC CH1 underrun Callback ID      */
+#if defined(DAC_CHANNEL2_SUPPORT)
+  HAL_DAC_CH2_COMPLETE_CB_ID                 = 0x04U,  /*!< DAC CH2 Complete Callback ID      */
+  HAL_DAC_CH2_HALF_COMPLETE_CB_ID            = 0x05U,  /*!< DAC CH2 half Complete Callback ID */
+  HAL_DAC_CH2_ERROR_ID                       = 0x06U,  /*!< DAC CH2 error Callback ID         */
+  HAL_DAC_CH2_UNDERRUN_CB_ID                 = 0x07U,  /*!< DAC CH2 underrun Callback ID      */
+#endif /* DAC_CHANNEL2_SUPPORT */
+  HAL_DAC_MSPINIT_CB_ID                      = 0x08U,  /*!< DAC MspInit Callback ID           */
+  HAL_DAC_MSPDEINIT_CB_ID                    = 0x09U,  /*!< DAC MspDeInit Callback ID         */
+  HAL_DAC_ALL_CB_ID                          = 0x0AU   /*!< DAC All ID                        */
+} HAL_DAC_CallbackIDTypeDef;
+
+/**
+  * @brief  HAL DAC Callback pointer definition
+  */
+typedef void (*pDAC_CallbackTypeDef)(DAC_HandleTypeDef *hdac);
+#endif /* USE_HAL_DAC_REGISTER_CALLBACKS */
+
+/**
+  * @}
+  */
+
+/* Exported constants --------------------------------------------------------*/
+
+/** @defgroup DAC_Exported_Constants DAC Exported Constants
+  * @{
+  */
+
+/** @defgroup DAC_Error_Code DAC Error Code
+  * @{
+  */
+#define  HAL_DAC_ERROR_NONE              0x00U    /*!< No error                          */
+#define  HAL_DAC_ERROR_DMAUNDERRUNCH1    0x01U    /*!< DAC channel1 DMA underrun error   */
+#if defined(DAC_CHANNEL2_SUPPORT)
+#define  HAL_DAC_ERROR_DMAUNDERRUNCH2    0x02U    /*!< DAC channel2 DMA underrun error   */
+#endif /* DAC_CHANNEL2_SUPPORT */
+#define  HAL_DAC_ERROR_DMA               0x04U    /*!< DMA error                         */
+#define  HAL_DAC_ERROR_TIMEOUT           0x08U    /*!< Timeout error                     */
+#if (USE_HAL_DAC_REGISTER_CALLBACKS == 1)
+#define HAL_DAC_ERROR_INVALID_CALLBACK   0x10U    /*!< Invalid callback error            */
+#endif /* USE_HAL_DAC_REGISTER_CALLBACKS */
+
+/**
+  * @}
+  */
+
+/** @defgroup DAC_trigger_selection DAC trigger selection
+  * @{
+  */
+#define DAC_TRIGGER_NONE                0x00000000UL                                                     /*!< Conversion is automatic once the DAC1_DHRxxxx register has been loaded, and not by external trigger */
+#define DAC_TRIGGER_T2_TRGO             (DAC_CR_TSEL1_2                                   | DAC_CR_TEN1) /*!< TIM2 TRGO selected as external conversion trigger for DAC channel */
+#define DAC_TRIGGER_T4_TRGO             (DAC_CR_TSEL1_2                  | DAC_CR_TSEL1_0 | DAC_CR_TEN1) /*!< TIM4 TRGO selected as external conversion trigger for DAC channel */
+#define DAC_TRIGGER_T5_TRGO             (                 DAC_CR_TSEL1_1 | DAC_CR_TSEL1_0 | DAC_CR_TEN1) /*!< TIM3 TRGO selected as external conversion trigger for DAC channel */
+#define DAC_TRIGGER_T6_TRGO             (                                                   DAC_CR_TEN1) /*!< Conversion started by software trigger for DAC channel */
+#define DAC_TRIGGER_T7_TRGO             (                 DAC_CR_TSEL1_1                  | DAC_CR_TEN1) /*!< TIM7 TRGO selected as external conversion trigger for DAC channel */
+#define DAC_TRIGGER_T8_TRGO             (                                  DAC_CR_TSEL1_0 | DAC_CR_TEN1) /*!< TIM8 TRGO selected as external conversion trigger for DAC channel */
+#define DAC_TRIGGER_EXT_IT9             (DAC_CR_TSEL1_2 | DAC_CR_TSEL1_1                  | DAC_CR_TEN1) /*!< EXTI Line9 event selected as external conversion trigger for DAC channel */
+#define DAC_TRIGGER_SOFTWARE            (DAC_CR_TSEL1                                     | DAC_CR_TEN1) /*!< Conversion started by software trigger for DAC channel */
+
+/**
+  * @}
+  */
+
+/** @defgroup DAC_output_buffer DAC output buffer
+  * @{
+  */
+#define DAC_OUTPUTBUFFER_ENABLE            0x00000000U
+#define DAC_OUTPUTBUFFER_DISABLE           (DAC_CR_BOFF1)
+
+/**
+  * @}
+  */
+
+/** @defgroup DAC_Channel_selection DAC Channel selection
+  * @{
+  */
+#define DAC_CHANNEL_1                      0x00000000U
+#if defined(DAC_CHANNEL2_SUPPORT)
+#define DAC_CHANNEL_2                      0x00000010U
+#endif /* DAC_CHANNEL2_SUPPORT */
+/**
+  * @}
+  */
+
+/** @defgroup DAC_data_alignment DAC data alignment
+  * @{
+  */
+#define DAC_ALIGN_12B_R                    0x00000000U
+#define DAC_ALIGN_12B_L                    0x00000004U
+#define DAC_ALIGN_8B_R                     0x00000008U
+
+/**
+  * @}
+  */
+
+/** @defgroup DAC_flags_definition DAC flags definition
+  * @{
+  */
+#define DAC_FLAG_DMAUDR1                   (DAC_SR_DMAUDR1)
+#if defined(DAC_CHANNEL2_SUPPORT)
+#define DAC_FLAG_DMAUDR2                   (DAC_SR_DMAUDR2)
+#endif /* DAC_CHANNEL2_SUPPORT */
+
+/**
+  * @}
+  */
+
+/** @defgroup DAC_IT_definition  DAC IT definition
+  * @{
+  */
+#define DAC_IT_DMAUDR1                   (DAC_SR_DMAUDR1)
+#if defined(DAC_CHANNEL2_SUPPORT)
+#define DAC_IT_DMAUDR2                   (DAC_SR_DMAUDR2)
+#endif /* DAC_CHANNEL2_SUPPORT */
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/* Exported macro ------------------------------------------------------------*/
+
+/** @defgroup DAC_Exported_Macros DAC Exported Macros
+  * @{
+  */
+
+/** @brief Reset DAC handle state.
+  * @param  __HANDLE__ specifies the DAC handle.
+  * @retval None
+  */
+#if (USE_HAL_DAC_REGISTER_CALLBACKS == 1)
+#define __HAL_DAC_RESET_HANDLE_STATE(__HANDLE__) do {                                                        \
+                                                      (__HANDLE__)->State             = HAL_DAC_STATE_RESET; \
+                                                      (__HANDLE__)->MspInitCallback   = NULL;                \
+                                                      (__HANDLE__)->MspDeInitCallback = NULL;                \
+                                                     } while(0)
+#else
+#define __HAL_DAC_RESET_HANDLE_STATE(__HANDLE__) ((__HANDLE__)->State = HAL_DAC_STATE_RESET)
+#endif /* USE_HAL_DAC_REGISTER_CALLBACKS */
+
+/** @brief Enable the DAC channel.
+  * @param  __HANDLE__ specifies the DAC handle.
+  * @param  __DAC_Channel__ specifies the DAC channel
+  * @retval None
+  */
+#define __HAL_DAC_ENABLE(__HANDLE__, __DAC_Channel__) \
+  ((__HANDLE__)->Instance->CR |=  (DAC_CR_EN1 << ((__DAC_Channel__) & 0x10UL)))
+
+/** @brief Disable the DAC channel.
+  * @param  __HANDLE__ specifies the DAC handle
+  * @param  __DAC_Channel__ specifies the DAC channel.
+  * @retval None
+  */
+#define __HAL_DAC_DISABLE(__HANDLE__, __DAC_Channel__) \
+  ((__HANDLE__)->Instance->CR &=  ~(DAC_CR_EN1 << ((__DAC_Channel__) & 0x10UL)))
+
+/** @brief Set DHR12R1 alignment.
+  * @param  __ALIGNMENT__ specifies the DAC alignment
+  * @retval None
+  */
+#define DAC_DHR12R1_ALIGNMENT(__ALIGNMENT__) (0x00000008UL + (__ALIGNMENT__))
+
+#if defined(DAC_CHANNEL2_SUPPORT)
+/** @brief  Set DHR12R2 alignment.
+  * @param  __ALIGNMENT__ specifies the DAC alignment
+  * @retval None
+  */
+#define DAC_DHR12R2_ALIGNMENT(__ALIGNMENT__) (0x00000014UL + (__ALIGNMENT__))
+#endif /* DAC_CHANNEL2_SUPPORT */
+
+/** @brief  Set DHR12RD alignment.
+  * @param  __ALIGNMENT__ specifies the DAC alignment
+  * @retval None
+  */
+#define DAC_DHR12RD_ALIGNMENT(__ALIGNMENT__) (0x00000020UL + (__ALIGNMENT__))
+
+/** @brief Enable the DAC interrupt.
+  * @param  __HANDLE__ specifies the DAC handle
+  * @param  __INTERRUPT__ specifies the DAC interrupt.
+  *          This parameter can be any combination of the following values:
+  *            @arg DAC_IT_DMAUDR1 DAC channel 1 DMA underrun interrupt
+  *            @arg DAC_IT_DMAUDR2 DAC channel 2 DMA underrun interrupt
+  * @retval None
+  */
+#define __HAL_DAC_ENABLE_IT(__HANDLE__, __INTERRUPT__) (((__HANDLE__)->Instance->CR) |= (__INTERRUPT__))
+
+/** @brief Disable the DAC interrupt.
+  * @param  __HANDLE__ specifies the DAC handle
+  * @param  __INTERRUPT__ specifies the DAC interrupt.
+  *          This parameter can be any combination of the following values:
+  *            @arg DAC_IT_DMAUDR1 DAC channel 1 DMA underrun interrupt
+  *            @arg DAC_IT_DMAUDR2 DAC channel 2 DMA underrun interrupt
+  * @retval None
+  */
+#define __HAL_DAC_DISABLE_IT(__HANDLE__, __INTERRUPT__) (((__HANDLE__)->Instance->CR) &= ~(__INTERRUPT__))
+
+/** @brief  Check whether the specified DAC interrupt source is enabled or not.
+  * @param __HANDLE__ DAC handle
+  * @param __INTERRUPT__ DAC interrupt source to check
+  *          This parameter can be any combination of the following values:
+  *            @arg DAC_IT_DMAUDR1 DAC channel 1 DMA underrun interrupt
+  *            @arg DAC_IT_DMAUDR2 DAC channel 2 DMA underrun interrupt
+  * @retval State of interruption (SET or RESET)
+  */
+#define __HAL_DAC_GET_IT_SOURCE(__HANDLE__, __INTERRUPT__) (((__HANDLE__)->Instance->CR\
+                                                             & (__INTERRUPT__)) == (__INTERRUPT__))
+
+/** @brief  Get the selected DAC's flag status.
+  * @param  __HANDLE__ specifies the DAC handle.
+  * @param  __FLAG__ specifies the DAC flag to get.
+  *          This parameter can be any combination of the following values:
+  *            @arg DAC_FLAG_DMAUDR1 DAC channel 1 DMA underrun flag
+  *            @arg DAC_FLAG_DMAUDR2 DAC channel 2 DMA underrun flag
+  * @retval None
+  */
+#define __HAL_DAC_GET_FLAG(__HANDLE__, __FLAG__) ((((__HANDLE__)->Instance->SR) & (__FLAG__)) == (__FLAG__))
+
+/** @brief  Clear the DAC's flag.
+  * @param  __HANDLE__ specifies the DAC handle.
+  * @param  __FLAG__ specifies the DAC flag to clear.
+  *          This parameter can be any combination of the following values:
+  *            @arg DAC_FLAG_DMAUDR1 DAC channel 1 DMA underrun flag
+  *            @arg DAC_FLAG_DMAUDR2 DAC channel 2 DMA underrun flag
+  * @retval None
+  */
+#define __HAL_DAC_CLEAR_FLAG(__HANDLE__, __FLAG__) (((__HANDLE__)->Instance->SR) = (__FLAG__))
+
+/**
+  * @}
+  */
+
+/* Private macro -------------------------------------------------------------*/
+
+/** @defgroup DAC_Private_Macros DAC Private Macros
+  * @{
+  */
+#define IS_DAC_OUTPUT_BUFFER_STATE(STATE) (((STATE) == DAC_OUTPUTBUFFER_ENABLE) || \
+                                           ((STATE) == DAC_OUTPUTBUFFER_DISABLE))
+
+#if defined(DAC_CHANNEL2_SUPPORT)
+#define IS_DAC_CHANNEL(CHANNEL) (((CHANNEL) == DAC_CHANNEL_1) || \
+                                 ((CHANNEL) == DAC_CHANNEL_2))
+#else
+#define IS_DAC_CHANNEL(CHANNEL)  ((CHANNEL) == DAC_CHANNEL_1)
+#endif /* DAC_CHANNEL2_SUPPORT */
+
+#define IS_DAC_ALIGN(ALIGN) (((ALIGN) == DAC_ALIGN_12B_R) || \
+                             ((ALIGN) == DAC_ALIGN_12B_L) || \
+                             ((ALIGN) == DAC_ALIGN_8B_R))
+
+#define IS_DAC_DATA(DATA) ((DATA) <= 0xFFF0UL)
+
+/**
+  * @}
+  */
+
+/* Include DAC HAL Extended module */
+#include "stm32f4xx_hal_dac_ex.h"
+
+/* Exported functions --------------------------------------------------------*/
+
+/** @addtogroup DAC_Exported_Functions
+  * @{
+  */
+
+/** @addtogroup DAC_Exported_Functions_Group1
+  * @{
+  */
+/* Initialization and de-initialization functions *****************************/
+HAL_StatusTypeDef HAL_DAC_Init(DAC_HandleTypeDef *hdac);
+HAL_StatusTypeDef HAL_DAC_DeInit(DAC_HandleTypeDef *hdac);
+void HAL_DAC_MspInit(DAC_HandleTypeDef *hdac);
+void HAL_DAC_MspDeInit(DAC_HandleTypeDef *hdac);
+
+/**
+  * @}
+  */
+
+/** @addtogroup DAC_Exported_Functions_Group2
+  * @{
+  */
+/* IO operation functions *****************************************************/
+HAL_StatusTypeDef HAL_DAC_Start(DAC_HandleTypeDef *hdac, uint32_t Channel);
+HAL_StatusTypeDef HAL_DAC_Stop(DAC_HandleTypeDef *hdac, uint32_t Channel);
+HAL_StatusTypeDef HAL_DAC_Start_DMA(DAC_HandleTypeDef *hdac, uint32_t Channel, uint32_t *pData, uint32_t Length,
+                                    uint32_t Alignment);
+HAL_StatusTypeDef HAL_DAC_Stop_DMA(DAC_HandleTypeDef *hdac, uint32_t Channel);
+void HAL_DAC_IRQHandler(DAC_HandleTypeDef *hdac);
+HAL_StatusTypeDef HAL_DAC_SetValue(DAC_HandleTypeDef *hdac, uint32_t Channel, uint32_t Alignment, uint32_t Data);
+
+void HAL_DAC_ConvCpltCallbackCh1(DAC_HandleTypeDef *hdac);
+void HAL_DAC_ConvHalfCpltCallbackCh1(DAC_HandleTypeDef *hdac);
+void HAL_DAC_ErrorCallbackCh1(DAC_HandleTypeDef *hdac);
+void HAL_DAC_DMAUnderrunCallbackCh1(DAC_HandleTypeDef *hdac);
+
+#if (USE_HAL_DAC_REGISTER_CALLBACKS == 1)
+/* DAC callback registering/unregistering */
+HAL_StatusTypeDef     HAL_DAC_RegisterCallback(DAC_HandleTypeDef *hdac, HAL_DAC_CallbackIDTypeDef CallbackID,
+                                               pDAC_CallbackTypeDef pCallback);
+HAL_StatusTypeDef     HAL_DAC_UnRegisterCallback(DAC_HandleTypeDef *hdac, HAL_DAC_CallbackIDTypeDef CallbackID);
+#endif /* USE_HAL_DAC_REGISTER_CALLBACKS */
+
+/**
+  * @}
+  */
+
+/** @addtogroup DAC_Exported_Functions_Group3
+  * @{
+  */
+/* Peripheral Control functions ***********************************************/
+uint32_t HAL_DAC_GetValue(DAC_HandleTypeDef *hdac, uint32_t Channel);
+HAL_StatusTypeDef HAL_DAC_ConfigChannel(DAC_HandleTypeDef *hdac, DAC_ChannelConfTypeDef *sConfig, uint32_t Channel);
+/**
+  * @}
+  */
+
+/** @addtogroup DAC_Exported_Functions_Group4
+  * @{
+  */
+/* Peripheral State and Error functions ***************************************/
+HAL_DAC_StateTypeDef HAL_DAC_GetState(DAC_HandleTypeDef *hdac);
+uint32_t HAL_DAC_GetError(DAC_HandleTypeDef *hdac);
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/** @defgroup DAC_Private_Functions DAC Private Functions
+  * @{
+  */
+void DAC_DMAConvCpltCh1(DMA_HandleTypeDef *hdma);
+void DAC_DMAErrorCh1(DMA_HandleTypeDef *hdma);
+void DAC_DMAHalfConvCpltCh1(DMA_HandleTypeDef *hdma);
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+#endif /* DAC */
+
+/**
+  * @}
+  */
+
+#ifdef __cplusplus
+}
+#endif
+
+
+#endif /* STM32F4xx_HAL_DAC_H */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/Drivers/STM32F4xx_HAL_Driver/Inc/stm32f4xx_hal_dac_ex.h
+++ b/Drivers/STM32F4xx_HAL_Driver/Inc/stm32f4xx_hal_dac_ex.h
@@ -1,0 +1,207 @@
+/**
+  ******************************************************************************
+  * @file    stm32f4xx_hal_dac_ex.h
+  * @author  MCD Application Team
+  * @brief   Header file of DAC HAL Extended module.
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; Copyright (c) 2016 STMicroelectronics.
+  * All rights reserved.</center></h2>
+  *
+  * This software component is licensed by ST under BSD 3-Clause license,
+  * the "License"; You may not use this file except in compliance with the
+  * License. You may obtain a copy of the License at:
+  *                        opensource.org/licenses/BSD-3-Clause
+  *
+  ******************************************************************************
+  */
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef STM32F4xx_HAL_DAC_EX_H
+#define STM32F4xx_HAL_DAC_EX_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/** @addtogroup STM32F4xx_HAL_Driver
+  * @{
+  */
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32f4xx_hal_def.h"
+
+#if defined(DAC)
+
+/** @addtogroup DACEx
+  * @{
+  */
+
+/* Exported types ------------------------------------------------------------*/
+
+/**
+  * @brief  HAL State structures definition
+  */
+
+/* Exported constants --------------------------------------------------------*/
+
+/** @defgroup DACEx_Exported_Constants DACEx Exported Constants
+  * @{
+  */
+
+/** @defgroup DACEx_lfsrunmask_triangleamplitude DACEx lfsrunmask triangle amplitude
+  * @{
+  */
+#define DAC_LFSRUNMASK_BIT0                0x00000000UL                                                        /*!< Unmask DAC channel LFSR bit0 for noise wave generation */
+#define DAC_LFSRUNMASK_BITS1_0             (                                                   DAC_CR_MAMP1_0) /*!< Unmask DAC channel LFSR bit[1:0] for noise wave generation */
+#define DAC_LFSRUNMASK_BITS2_0             (                                  DAC_CR_MAMP1_1                 ) /*!< Unmask DAC channel LFSR bit[2:0] for noise wave generation */
+#define DAC_LFSRUNMASK_BITS3_0             (                                  DAC_CR_MAMP1_1 | DAC_CR_MAMP1_0) /*!< Unmask DAC channel LFSR bit[3:0] for noise wave generation */
+#define DAC_LFSRUNMASK_BITS4_0             (                 DAC_CR_MAMP1_2                                  ) /*!< Unmask DAC channel LFSR bit[4:0] for noise wave generation */
+#define DAC_LFSRUNMASK_BITS5_0             (                 DAC_CR_MAMP1_2                  | DAC_CR_MAMP1_0) /*!< Unmask DAC channel LFSR bit[5:0] for noise wave generation */
+#define DAC_LFSRUNMASK_BITS6_0             (                 DAC_CR_MAMP1_2 | DAC_CR_MAMP1_1                 ) /*!< Unmask DAC channel LFSR bit[6:0] for noise wave generation */
+#define DAC_LFSRUNMASK_BITS7_0             (                 DAC_CR_MAMP1_2 | DAC_CR_MAMP1_1 | DAC_CR_MAMP1_0) /*!< Unmask DAC channel LFSR bit[7:0] for noise wave generation */
+#define DAC_LFSRUNMASK_BITS8_0             (DAC_CR_MAMP1_3                                                   ) /*!< Unmask DAC channel LFSR bit[8:0] for noise wave generation */
+#define DAC_LFSRUNMASK_BITS9_0             (DAC_CR_MAMP1_3                                   | DAC_CR_MAMP1_0) /*!< Unmask DAC channel LFSR bit[9:0] for noise wave generation */
+#define DAC_LFSRUNMASK_BITS10_0            (DAC_CR_MAMP1_3                  | DAC_CR_MAMP1_1                 ) /*!< Unmask DAC channel LFSR bit[10:0] for noise wave generation */
+#define DAC_LFSRUNMASK_BITS11_0            (DAC_CR_MAMP1_3                  | DAC_CR_MAMP1_1 | DAC_CR_MAMP1_0) /*!< Unmask DAC channel LFSR bit[11:0] for noise wave generation */
+#define DAC_TRIANGLEAMPLITUDE_1            0x00000000UL                                                        /*!< Select max triangle amplitude of 1 */
+#define DAC_TRIANGLEAMPLITUDE_3            (                                                   DAC_CR_MAMP1_0) /*!< Select max triangle amplitude of 3 */
+#define DAC_TRIANGLEAMPLITUDE_7            (                                  DAC_CR_MAMP1_1                 ) /*!< Select max triangle amplitude of 7 */
+#define DAC_TRIANGLEAMPLITUDE_15           (                                  DAC_CR_MAMP1_1 | DAC_CR_MAMP1_0) /*!< Select max triangle amplitude of 15 */
+#define DAC_TRIANGLEAMPLITUDE_31           (                 DAC_CR_MAMP1_2                                  ) /*!< Select max triangle amplitude of 31 */
+#define DAC_TRIANGLEAMPLITUDE_63           (                 DAC_CR_MAMP1_2                  | DAC_CR_MAMP1_0) /*!< Select max triangle amplitude of 63 */
+#define DAC_TRIANGLEAMPLITUDE_127          (                 DAC_CR_MAMP1_2 | DAC_CR_MAMP1_1                 ) /*!< Select max triangle amplitude of 127 */
+#define DAC_TRIANGLEAMPLITUDE_255          (                 DAC_CR_MAMP1_2 | DAC_CR_MAMP1_1 | DAC_CR_MAMP1_0) /*!< Select max triangle amplitude of 255 */
+#define DAC_TRIANGLEAMPLITUDE_511          (DAC_CR_MAMP1_3                                                   ) /*!< Select max triangle amplitude of 511 */
+#define DAC_TRIANGLEAMPLITUDE_1023         (DAC_CR_MAMP1_3                                   | DAC_CR_MAMP1_0) /*!< Select max triangle amplitude of 1023 */
+#define DAC_TRIANGLEAMPLITUDE_2047         (DAC_CR_MAMP1_3                  | DAC_CR_MAMP1_1                 ) /*!< Select max triangle amplitude of 2047 */
+#define DAC_TRIANGLEAMPLITUDE_4095         (DAC_CR_MAMP1_3                  | DAC_CR_MAMP1_1 | DAC_CR_MAMP1_0) /*!< Select max triangle amplitude of 4095 */
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/* Exported macro ------------------------------------------------------------*/
+
+
+/* Private macro -------------------------------------------------------------*/
+
+/** @defgroup DACEx_Private_Macros DACEx Private Macros
+  * @{
+  */
+#define IS_DAC_TRIGGER(TRIGGER) (((TRIGGER) == DAC_TRIGGER_NONE)    || \
+                                 ((TRIGGER) == DAC_TRIGGER_T2_TRGO) || \
+                                 ((TRIGGER) == DAC_TRIGGER_T8_TRGO) || \
+                                 ((TRIGGER) == DAC_TRIGGER_T7_TRGO) || \
+                                 ((TRIGGER) == DAC_TRIGGER_T5_TRGO) || \
+                                 ((TRIGGER) == DAC_TRIGGER_T6_TRGO) || \
+                                 ((TRIGGER) == DAC_TRIGGER_T4_TRGO) || \
+                                 ((TRIGGER) == DAC_TRIGGER_EXT_IT9) || \
+                                 ((TRIGGER) == DAC_TRIGGER_SOFTWARE))
+
+#define IS_DAC_LFSR_UNMASK_TRIANGLE_AMPLITUDE(VALUE) (((VALUE) == DAC_LFSRUNMASK_BIT0) || \
+                                                      ((VALUE) == DAC_LFSRUNMASK_BITS1_0) || \
+                                                      ((VALUE) == DAC_LFSRUNMASK_BITS2_0) || \
+                                                      ((VALUE) == DAC_LFSRUNMASK_BITS3_0) || \
+                                                      ((VALUE) == DAC_LFSRUNMASK_BITS4_0) || \
+                                                      ((VALUE) == DAC_LFSRUNMASK_BITS5_0) || \
+                                                      ((VALUE) == DAC_LFSRUNMASK_BITS6_0) || \
+                                                      ((VALUE) == DAC_LFSRUNMASK_BITS7_0) || \
+                                                      ((VALUE) == DAC_LFSRUNMASK_BITS8_0) || \
+                                                      ((VALUE) == DAC_LFSRUNMASK_BITS9_0) || \
+                                                      ((VALUE) == DAC_LFSRUNMASK_BITS10_0) || \
+                                                      ((VALUE) == DAC_LFSRUNMASK_BITS11_0) || \
+                                                      ((VALUE) == DAC_TRIANGLEAMPLITUDE_1) || \
+                                                      ((VALUE) == DAC_TRIANGLEAMPLITUDE_3) || \
+                                                      ((VALUE) == DAC_TRIANGLEAMPLITUDE_7) || \
+                                                      ((VALUE) == DAC_TRIANGLEAMPLITUDE_15) || \
+                                                      ((VALUE) == DAC_TRIANGLEAMPLITUDE_31) || \
+                                                      ((VALUE) == DAC_TRIANGLEAMPLITUDE_63) || \
+                                                      ((VALUE) == DAC_TRIANGLEAMPLITUDE_127) || \
+                                                      ((VALUE) == DAC_TRIANGLEAMPLITUDE_255) || \
+                                                      ((VALUE) == DAC_TRIANGLEAMPLITUDE_511) || \
+                                                      ((VALUE) == DAC_TRIANGLEAMPLITUDE_1023) || \
+                                                      ((VALUE) == DAC_TRIANGLEAMPLITUDE_2047) || \
+                                                      ((VALUE) == DAC_TRIANGLEAMPLITUDE_4095))
+/**
+  * @}
+  */
+
+/* Exported functions --------------------------------------------------------*/
+/* Extended features functions ***********************************************/
+
+/** @addtogroup DACEx_Exported_Functions
+  * @{
+  */
+
+/** @addtogroup DACEx_Exported_Functions_Group2
+  * @{
+  */
+/* IO operation functions *****************************************************/
+
+HAL_StatusTypeDef HAL_DACEx_TriangleWaveGenerate(DAC_HandleTypeDef *hdac, uint32_t Channel, uint32_t Amplitude);
+HAL_StatusTypeDef HAL_DACEx_NoiseWaveGenerate(DAC_HandleTypeDef *hdac, uint32_t Channel, uint32_t Amplitude);
+
+#if defined(DAC_CHANNEL2_SUPPORT)
+#endif
+HAL_StatusTypeDef HAL_DACEx_DualStart(DAC_HandleTypeDef *hdac);
+HAL_StatusTypeDef HAL_DACEx_DualStop(DAC_HandleTypeDef *hdac);
+HAL_StatusTypeDef HAL_DACEx_DualSetValue(DAC_HandleTypeDef *hdac, uint32_t Alignment, uint32_t Data1, uint32_t Data2);
+uint32_t HAL_DACEx_DualGetValue(DAC_HandleTypeDef *hdac);
+
+#if defined(DAC_CHANNEL2_SUPPORT)
+#endif
+void HAL_DACEx_ConvCpltCallbackCh2(DAC_HandleTypeDef *hdac);
+void HAL_DACEx_ConvHalfCpltCallbackCh2(DAC_HandleTypeDef *hdac);
+void HAL_DACEx_ErrorCallbackCh2(DAC_HandleTypeDef *hdac);
+void HAL_DACEx_DMAUnderrunCallbackCh2(DAC_HandleTypeDef *hdac);
+
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/** @addtogroup DACEx_Private_Functions
+  * @{
+  */
+#if defined(DAC_CHANNEL2_SUPPORT)
+/* DAC_DMAConvCpltCh2 / DAC_DMAErrorCh2 / DAC_DMAHalfConvCpltCh2 */
+/* are called by HAL_DAC_Start_DMA */
+void DAC_DMAConvCpltCh2(DMA_HandleTypeDef *hdma);
+void DAC_DMAErrorCh2(DMA_HandleTypeDef *hdma);
+void DAC_DMAHalfConvCpltCh2(DMA_HandleTypeDef *hdma);
+#endif /* DAC_CHANNEL2_SUPPORT */
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+#endif /* DAC */
+
+/**
+  * @}
+  */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* STM32F4xx_HAL_DAC_EX_H */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/Drivers/STM32F4xx_HAL_Driver/Src/stm32f4xx_hal_dac.c
+++ b/Drivers/STM32F4xx_HAL_Driver/Src/stm32f4xx_hal_dac.c
@@ -1,0 +1,1342 @@
+/**
+  ******************************************************************************
+  * @file    stm32f4xx_hal_dac.c
+  * @author  MCD Application Team
+  * @brief   DAC HAL module driver.
+  *         This file provides firmware functions to manage the following
+  *         functionalities of the Digital to Analog Converter (DAC) peripheral:
+  *           + Initialization and de-initialization functions
+  *           + IO operation functions
+  *           + Peripheral Control functions
+  *           + Peripheral State and Errors functions
+  *
+  *
+  @verbatim
+  ==============================================================================
+                      ##### DAC Peripheral features #####
+  ==============================================================================
+    [..]
+      *** DAC Channels ***
+      ====================
+    [..]
+    STM32F4 devices integrate two 12-bit Digital Analog Converters
+
+    The 2 converters (i.e. channel1 & channel2)
+    can be used independently or simultaneously (dual mode):
+      (#) DAC channel1 with DAC_OUT1 (PA4) as output
+      (#) DAC channel2 with DAC_OUT2 (PA5) as output
+
+      *** DAC Triggers ***
+      ====================
+    [..]
+    Digital to Analog conversion can be non-triggered using DAC_TRIGGER_NONE
+    and DAC_OUT1/DAC_OUT2 is available once writing to DHRx register.
+    [..]
+    Digital to Analog conversion can be triggered by:
+      (#) External event: EXTI Line 9 (any GPIOx_PIN_9) using DAC_TRIGGER_EXT_IT9.
+          The used pin (GPIOx_PIN_9) must be configured in input mode.
+
+      (#) Timers TRGO: TIM2, TIM4, TIM5, TIM6, TIM7 and TIM8
+          (DAC_TRIGGER_T2_TRGO, DAC_TRIGGER_T4_TRGO...)
+
+      (#) Software using DAC_TRIGGER_SOFTWARE
+
+      *** DAC Buffer mode feature ***
+      ===============================
+      [..]
+      Each DAC channel integrates an output buffer that can be used to
+      reduce the output impedance, and to drive external loads directly
+      without having to add an external operational amplifier.
+      To enable, the output buffer use
+      sConfig.DAC_OutputBuffer = DAC_OUTPUTBUFFER_ENABLE;
+      [..]
+      (@) Refer to the device datasheet for more details about output
+          impedance value with and without output buffer.
+
+       *** DAC wave generation feature ***
+       ===================================
+       [..]
+       Both DAC channels can be used to generate
+         (#) Noise wave
+         (#) Triangle wave
+
+       *** DAC data format ***
+       =======================
+       [..]
+       The DAC data format can be:
+         (#) 8-bit right alignment using DAC_ALIGN_8B_R
+         (#) 12-bit left alignment using DAC_ALIGN_12B_L
+         (#) 12-bit right alignment using DAC_ALIGN_12B_R
+
+       *** DAC data value to voltage correspondence ***
+       ================================================
+       [..]
+       The analog output voltage on each DAC channel pin is determined
+       by the following equation:
+       [..]
+       DAC_OUTx = VREF+ * DOR / 4095
+       (+) with  DOR is the Data Output Register
+       [..]
+          VREF+ is the input voltage reference (refer to the device datasheet)
+       [..]
+        e.g. To set DAC_OUT1 to 0.7V, use
+       (+) Assuming that VREF+ = 3.3V, DAC_OUT1 = (3.3 * 868) / 4095 = 0.7V
+
+       *** DMA requests ***
+       =====================
+       [..]
+       A DMA request can be generated when an external trigger (but not a software trigger)
+       occurs if DMA1 requests are enabled using HAL_DAC_Start_DMA().
+       DMA1 requests are mapped as following:
+      (#) DAC channel1 mapped on DMA1 Stream5 channel7 which must be 
+          already configured
+      (#) DAC channel2 mapped on DMA1 Stream6 channel7 which must be 
+          already configured
+
+     [..]
+    (@) For Dual mode and specific signal (Triangle and noise) generation please
+        refer to Extended Features Driver description
+
+                      ##### How to use this driver #####
+  ==============================================================================
+    [..]
+      (+) DAC APB clock must be enabled to get write access to DAC
+          registers using HAL_DAC_Init()
+      (+) Configure DAC_OUTx (DAC_OUT1: PA4, DAC_OUT2: PA5) in analog mode.
+      (+) Configure the DAC channel using HAL_DAC_ConfigChannel() function.
+      (+) Enable the DAC channel using HAL_DAC_Start() or HAL_DAC_Start_DMA() functions.
+
+
+     *** Polling mode IO operation ***
+     =================================
+     [..]
+       (+) Start the DAC peripheral using HAL_DAC_Start()
+       (+) To read the DAC last data output value, use the HAL_DAC_GetValue() function.
+       (+) Stop the DAC peripheral using HAL_DAC_Stop()
+
+     *** DMA mode IO operation ***
+     ==============================
+     [..]
+       (+) Start the DAC peripheral using HAL_DAC_Start_DMA(), at this stage the user specify the length
+           of data to be transferred at each end of conversion
+           First issued trigger will start the conversion of the value previously set by HAL_DAC_SetValue().
+       (+) At the middle of data transfer HAL_DAC_ConvHalfCpltCallbackCh1() or HAL_DACEx_ConvHalfCpltCallbackCh2()
+           function is executed and user can add his own code by customization of function pointer
+           HAL_DAC_ConvHalfCpltCallbackCh1() or HAL_DACEx_ConvHalfCpltCallbackCh2()
+       (+) At The end of data transfer HAL_DAC_ConvCpltCallbackCh1() or HAL_DACEx_ConvHalfCpltCallbackCh2()
+           function is executed and user can add his own code by customization of function pointer
+           HAL_DAC_ConvCpltCallbackCh1() or HAL_DACEx_ConvHalfCpltCallbackCh2()
+       (+) In case of transfer Error, HAL_DAC_ErrorCallbackCh1() function is executed and user can
+            add his own code by customization of function pointer HAL_DAC_ErrorCallbackCh1
+       (+) In case of DMA underrun, DAC interruption triggers and execute internal function HAL_DAC_IRQHandler.
+           HAL_DAC_DMAUnderrunCallbackCh1() or HAL_DACEx_DMAUnderrunCallbackCh2()
+           function is executed and user can add his own code by customization of function pointer
+           HAL_DAC_DMAUnderrunCallbackCh1() or HAL_DACEx_DMAUnderrunCallbackCh2() and
+           add his own code by customization of function pointer HAL_DAC_ErrorCallbackCh1()
+       (+) Stop the DAC peripheral using HAL_DAC_Stop_DMA()
+
+    *** Callback registration ***
+    =============================================
+    [..]
+      The compilation define  USE_HAL_DAC_REGISTER_CALLBACKS when set to 1
+      allows the user to configure dynamically the driver callbacks.
+
+    Use Functions HAL_DAC_RegisterCallback() to register a user callback,
+      it allows to register following callbacks:
+      (+) ConvCpltCallbackCh1     : callback when a half transfer is completed on Ch1.
+      (+) ConvHalfCpltCallbackCh1 : callback when a transfer is completed on Ch1.
+      (+) ErrorCallbackCh1        : callback when an error occurs on Ch1.
+      (+) DMAUnderrunCallbackCh1  : callback when an underrun error occurs on Ch1.
+      (+) ConvCpltCallbackCh2     : callback when a half transfer is completed on Ch2.
+      (+) ConvHalfCpltCallbackCh2 : callback when a transfer is completed on Ch2.
+      (+) ErrorCallbackCh2        : callback when an error occurs on Ch2.
+      (+) DMAUnderrunCallbackCh2  : callback when an underrun error occurs on Ch2.
+      (+) MspInitCallback         : DAC MspInit.
+      (+) MspDeInitCallback       : DAC MspdeInit.
+      This function takes as parameters the HAL peripheral handle, the Callback ID
+      and a pointer to the user callback function.
+
+    Use function HAL_DAC_UnRegisterCallback() to reset a callback to the default
+      weak (surcharged) function. It allows to reset following callbacks:
+      (+) ConvCpltCallbackCh1     : callback when a half transfer is completed on Ch1.
+      (+) ConvHalfCpltCallbackCh1 : callback when a transfer is completed on Ch1.
+      (+) ErrorCallbackCh1        : callback when an error occurs on Ch1.
+      (+) DMAUnderrunCallbackCh1  : callback when an underrun error occurs on Ch1.
+      (+) ConvCpltCallbackCh2     : callback when a half transfer is completed on Ch2.
+      (+) ConvHalfCpltCallbackCh2 : callback when a transfer is completed on Ch2.
+      (+) ErrorCallbackCh2        : callback when an error occurs on Ch2.
+      (+) DMAUnderrunCallbackCh2  : callback when an underrun error occurs on Ch2.
+      (+) MspInitCallback         : DAC MspInit.
+      (+) MspDeInitCallback       : DAC MspdeInit.
+      (+) All Callbacks
+      This function) takes as parameters the HAL peripheral handle and the Callback ID.
+
+      By default, after the HAL_DAC_Init and if the state is HAL_DAC_STATE_RESET
+      all callbacks are reset to the corresponding legacy weak (surcharged) functions.
+      Exception done for MspInit and MspDeInit callbacks that are respectively
+      reset to the legacy weak (surcharged) functions in the HAL_DAC_Init
+      and  HAL_DAC_DeInit only when these callbacks are null (not registered beforehand).
+      If not, MspInit or MspDeInit are not null, the HAL_DAC_Init and HAL_DAC_DeInit
+      keep and use the user MspInit/MspDeInit callbacks (registered beforehand)
+
+      Callbacks can be registered/unregistered in READY state only.
+      Exception done for MspInit/MspDeInit callbacks that can be registered/unregistered
+      in READY or RESET state, thus registered (user) MspInit/DeInit callbacks can be used
+      during the Init/DeInit.
+      In that case first register the MspInit/MspDeInit user callbacks
+      using HAL_DAC_RegisterCallback before calling HAL_DAC_DeInit
+      or HAL_DAC_Init function.
+
+      When The compilation define USE_HAL_DAC_REGISTER_CALLBACKS is set to 0 or
+      not defined, the callback registering feature is not available
+      and weak (surcharged) callbacks are used.
+
+     *** DAC HAL driver macros list ***
+     =============================================
+     [..]
+       Below the list of most used macros in DAC HAL driver.
+
+      (+) __HAL_DAC_ENABLE : Enable the DAC peripheral
+      (+) __HAL_DAC_DISABLE : Disable the DAC peripheral
+      (+) __HAL_DAC_CLEAR_FLAG: Clear the DAC's pending flags
+      (+) __HAL_DAC_GET_FLAG: Get the selected DAC's flag status
+
+     [..]
+      (@) You can refer to the DAC HAL driver header file for more useful macros
+
+@endverbatim
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; Copyright (c) 2016 STMicroelectronics.
+  * All rights reserved.</center></h2>
+  *
+  * This software component is licensed by ST under BSD 3-Clause license,
+  * the "License"; You may not use this file except in compliance with the
+  * License. You may obtain a copy of the License at:
+  *                        opensource.org/licenses/BSD-3-Clause
+  *
+  ******************************************************************************
+  */
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32f4xx_hal.h"
+
+/** @addtogroup STM32F4xx_HAL_Driver
+  * @{
+  */
+
+#ifdef HAL_DAC_MODULE_ENABLED
+#if defined(DAC)
+
+/** @defgroup DAC DAC
+  * @brief DAC driver modules
+  * @{
+  */
+
+/* Private typedef -----------------------------------------------------------*/
+/* Private define ------------------------------------------------------------*/
+/* Private constants ---------------------------------------------------------*/
+/* Private macro -------------------------------------------------------------*/
+/* Private variables ---------------------------------------------------------*/
+/* Private function prototypes -----------------------------------------------*/
+/* Exported functions -------------------------------------------------------*/
+
+/** @defgroup DAC_Exported_Functions DAC Exported Functions
+  * @{
+  */
+
+/** @defgroup DAC_Exported_Functions_Group1 Initialization and de-initialization functions
+  *  @brief    Initialization and Configuration functions
+  *
+@verbatim
+  ==============================================================================
+              ##### Initialization and de-initialization functions #####
+  ==============================================================================
+    [..]  This section provides functions allowing to:
+      (+) Initialize and configure the DAC.
+      (+) De-initialize the DAC.
+
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief  Initialize the DAC peripheral according to the specified parameters
+  *         in the DAC_InitStruct and initialize the associated handle.
+  * @param  hdac pointer to a DAC_HandleTypeDef structure that contains
+  *         the configuration information for the specified DAC.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_DAC_Init(DAC_HandleTypeDef *hdac)
+{
+  /* Check DAC handle */
+  if (hdac == NULL)
+  {
+    return HAL_ERROR;
+  }
+  /* Check the parameters */
+  assert_param(IS_DAC_ALL_INSTANCE(hdac->Instance));
+
+  if (hdac->State == HAL_DAC_STATE_RESET)
+  {
+#if (USE_HAL_DAC_REGISTER_CALLBACKS == 1)
+    /* Init the DAC Callback settings */
+    hdac->ConvCpltCallbackCh1           = HAL_DAC_ConvCpltCallbackCh1;
+    hdac->ConvHalfCpltCallbackCh1       = HAL_DAC_ConvHalfCpltCallbackCh1;
+    hdac->ErrorCallbackCh1              = HAL_DAC_ErrorCallbackCh1;
+    hdac->DMAUnderrunCallbackCh1        = HAL_DAC_DMAUnderrunCallbackCh1;
+#if defined(DAC_CHANNEL2_SUPPORT)
+    hdac->ConvCpltCallbackCh2           = HAL_DACEx_ConvCpltCallbackCh2;
+    hdac->ConvHalfCpltCallbackCh2       = HAL_DACEx_ConvHalfCpltCallbackCh2;
+    hdac->ErrorCallbackCh2              = HAL_DACEx_ErrorCallbackCh2;
+    hdac->DMAUnderrunCallbackCh2        = HAL_DACEx_DMAUnderrunCallbackCh2;
+#endif /* DAC_CHANNEL2_SUPPORT */
+    if (hdac->MspInitCallback == NULL)
+    {
+      hdac->MspInitCallback             = HAL_DAC_MspInit;
+    }
+#endif /* USE_HAL_DAC_REGISTER_CALLBACKS */
+
+    /* Allocate lock resource and initialize it */
+    hdac->Lock = HAL_UNLOCKED;
+
+#if (USE_HAL_DAC_REGISTER_CALLBACKS == 1)
+    /* Init the low level hardware */
+    hdac->MspInitCallback(hdac);
+#else
+    /* Init the low level hardware */
+    HAL_DAC_MspInit(hdac);
+#endif /* USE_HAL_DAC_REGISTER_CALLBACKS */
+  }
+
+  /* Initialize the DAC state*/
+  hdac->State = HAL_DAC_STATE_BUSY;
+
+  /* Set DAC error code to none */
+  hdac->ErrorCode = HAL_DAC_ERROR_NONE;
+
+  /* Initialize the DAC state*/
+  hdac->State = HAL_DAC_STATE_READY;
+
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Deinitialize the DAC peripheral registers to their default reset values.
+  * @param  hdac pointer to a DAC_HandleTypeDef structure that contains
+  *         the configuration information for the specified DAC.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_DAC_DeInit(DAC_HandleTypeDef *hdac)
+{
+  /* Check DAC handle */
+  if (hdac == NULL)
+  {
+    return HAL_ERROR;
+  }
+
+  /* Check the parameters */
+  assert_param(IS_DAC_ALL_INSTANCE(hdac->Instance));
+
+  /* Change DAC state */
+  hdac->State = HAL_DAC_STATE_BUSY;
+
+#if (USE_HAL_DAC_REGISTER_CALLBACKS == 1)
+  if (hdac->MspDeInitCallback == NULL)
+  {
+    hdac->MspDeInitCallback = HAL_DAC_MspDeInit;
+  }
+  /* DeInit the low level hardware */
+  hdac->MspDeInitCallback(hdac);
+#else
+  /* DeInit the low level hardware */
+  HAL_DAC_MspDeInit(hdac);
+#endif /* USE_HAL_DAC_REGISTER_CALLBACKS */
+
+  /* Set DAC error code to none */
+  hdac->ErrorCode = HAL_DAC_ERROR_NONE;
+
+  /* Change DAC state */
+  hdac->State = HAL_DAC_STATE_RESET;
+
+  /* Release Lock */
+  __HAL_UNLOCK(hdac);
+
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Initialize the DAC MSP.
+  * @param  hdac pointer to a DAC_HandleTypeDef structure that contains
+  *         the configuration information for the specified DAC.
+  * @retval None
+  */
+__weak void HAL_DAC_MspInit(DAC_HandleTypeDef *hdac)
+{
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(hdac);
+
+  /* NOTE : This function should not be modified, when the callback is needed,
+            the HAL_DAC_MspInit could be implemented in the user file
+   */
+}
+
+/**
+  * @brief  DeInitialize the DAC MSP.
+  * @param  hdac pointer to a DAC_HandleTypeDef structure that contains
+  *         the configuration information for the specified DAC.
+  * @retval None
+  */
+__weak void HAL_DAC_MspDeInit(DAC_HandleTypeDef *hdac)
+{
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(hdac);
+
+  /* NOTE : This function should not be modified, when the callback is needed,
+            the HAL_DAC_MspDeInit could be implemented in the user file
+   */
+}
+
+/**
+  * @}
+  */
+
+/** @defgroup DAC_Exported_Functions_Group2 IO operation functions
+  *  @brief    IO operation functions
+  *
+@verbatim
+  ==============================================================================
+             ##### IO operation functions #####
+  ==============================================================================
+    [..]  This section provides functions allowing to:
+      (+) Start conversion.
+      (+) Stop conversion.
+      (+) Start conversion and enable DMA transfer.
+      (+) Stop conversion and disable DMA transfer.
+      (+) Get result of conversion.
+
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief  Enables DAC and starts conversion of channel.
+  * @param  hdac pointer to a DAC_HandleTypeDef structure that contains
+  *         the configuration information for the specified DAC.
+  * @param  Channel The selected DAC channel.
+  *          This parameter can be one of the following values:
+  *            @arg DAC_CHANNEL_1: DAC Channel1 selected
+  *            @arg DAC_CHANNEL_2: DAC Channel2 selected
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_DAC_Start(DAC_HandleTypeDef *hdac, uint32_t Channel)
+{
+  /* Check the parameters */
+  assert_param(IS_DAC_CHANNEL(Channel));
+
+  /* Process locked */
+  __HAL_LOCK(hdac);
+
+  /* Change DAC state */
+  hdac->State = HAL_DAC_STATE_BUSY;
+
+  /* Enable the Peripheral */
+  __HAL_DAC_ENABLE(hdac, Channel);
+
+  if (Channel == DAC_CHANNEL_1)
+  {
+    /* Check if software trigger enabled */
+    if ((hdac->Instance->CR & (DAC_CR_TEN1 | DAC_CR_TSEL1)) == DAC_TRIGGER_SOFTWARE)
+    {
+      /* Enable the selected DAC software conversion */
+      SET_BIT(hdac->Instance->SWTRIGR, DAC_SWTRIGR_SWTRIG1);
+    }
+  }
+#if defined(DAC_CHANNEL2_SUPPORT)
+  else
+  {
+    /* Check if software trigger enabled */
+    if ((hdac->Instance->CR & (DAC_CR_TEN2 | DAC_CR_TSEL2)) == (DAC_TRIGGER_SOFTWARE << (Channel & 0x10UL)))
+    {
+      /* Enable the selected DAC software conversion*/
+      SET_BIT(hdac->Instance->SWTRIGR, DAC_SWTRIGR_SWTRIG2);
+    }
+  }
+#endif /* DAC_CHANNEL2_SUPPORT */
+
+  /* Change DAC state */
+  hdac->State = HAL_DAC_STATE_READY;
+
+  /* Process unlocked */
+  __HAL_UNLOCK(hdac);
+
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Disables DAC and stop conversion of channel.
+  * @param  hdac pointer to a DAC_HandleTypeDef structure that contains
+  *         the configuration information for the specified DAC.
+  * @param  Channel The selected DAC channel.
+  *          This parameter can be one of the following values:
+  *            @arg DAC_CHANNEL_1: DAC Channel1 selected
+  *            @arg DAC_CHANNEL_2: DAC Channel2 selected
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_DAC_Stop(DAC_HandleTypeDef *hdac, uint32_t Channel)
+{
+  /* Check the parameters */
+  assert_param(IS_DAC_CHANNEL(Channel));
+
+  /* Disable the Peripheral */
+  __HAL_DAC_DISABLE(hdac, Channel);
+
+  /* Change DAC state */
+  hdac->State = HAL_DAC_STATE_READY;
+
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Enables DAC and starts conversion of channel.
+  * @param  hdac pointer to a DAC_HandleTypeDef structure that contains
+  *         the configuration information for the specified DAC.
+  * @param  Channel The selected DAC channel.
+  *          This parameter can be one of the following values:
+  *            @arg DAC_CHANNEL_1: DAC Channel1 selected
+  *            @arg DAC_CHANNEL_2: DAC Channel2 selected
+  * @param  pData The source Buffer address.
+  * @param  Length The length of data to be transferred from memory to DAC peripheral
+  * @param  Alignment Specifies the data alignment for DAC channel.
+  *          This parameter can be one of the following values:
+  *            @arg DAC_ALIGN_8B_R: 8bit right data alignment selected
+  *            @arg DAC_ALIGN_12B_L: 12bit left data alignment selected
+  *            @arg DAC_ALIGN_12B_R: 12bit right data alignment selected
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_DAC_Start_DMA(DAC_HandleTypeDef *hdac, uint32_t Channel, uint32_t *pData, uint32_t Length,
+                                    uint32_t Alignment)
+{
+  HAL_StatusTypeDef status = HAL_OK;
+  uint32_t tmpreg = 0U;
+
+  /* Check the parameters */
+  assert_param(IS_DAC_CHANNEL(Channel));
+  assert_param(IS_DAC_ALIGN(Alignment));
+
+  /* Process locked */
+  __HAL_LOCK(hdac);
+
+  /* Change DAC state */
+  hdac->State = HAL_DAC_STATE_BUSY;
+
+  if (Channel == DAC_CHANNEL_1)
+  {
+    /* Set the DMA transfer complete callback for channel1 */
+    hdac->DMA_Handle1->XferCpltCallback = DAC_DMAConvCpltCh1;
+
+    /* Set the DMA half transfer complete callback for channel1 */
+    hdac->DMA_Handle1->XferHalfCpltCallback = DAC_DMAHalfConvCpltCh1;
+
+    /* Set the DMA error callback for channel1 */
+    hdac->DMA_Handle1->XferErrorCallback = DAC_DMAErrorCh1;
+
+    /* Enable the selected DAC channel1 DMA request */
+    SET_BIT(hdac->Instance->CR, DAC_CR_DMAEN1);
+
+    /* Case of use of channel 1 */
+    switch (Alignment)
+    {
+      case DAC_ALIGN_12B_R:
+        /* Get DHR12R1 address */
+        tmpreg = (uint32_t)&hdac->Instance->DHR12R1;
+        break;
+      case DAC_ALIGN_12B_L:
+        /* Get DHR12L1 address */
+        tmpreg = (uint32_t)&hdac->Instance->DHR12L1;
+        break;
+      case DAC_ALIGN_8B_R:
+        /* Get DHR8R1 address */
+        tmpreg = (uint32_t)&hdac->Instance->DHR8R1;
+        break;
+      default:
+        break;
+    }
+  }
+#if defined(DAC_CHANNEL2_SUPPORT)
+  else
+  {
+    /* Set the DMA transfer complete callback for channel2 */
+    hdac->DMA_Handle2->XferCpltCallback = DAC_DMAConvCpltCh2;
+
+    /* Set the DMA half transfer complete callback for channel2 */
+    hdac->DMA_Handle2->XferHalfCpltCallback = DAC_DMAHalfConvCpltCh2;
+
+    /* Set the DMA error callback for channel2 */
+    hdac->DMA_Handle2->XferErrorCallback = DAC_DMAErrorCh2;
+
+    /* Enable the selected DAC channel2 DMA request */
+    SET_BIT(hdac->Instance->CR, DAC_CR_DMAEN2);
+
+    /* Case of use of channel 2 */
+    switch (Alignment)
+    {
+      case DAC_ALIGN_12B_R:
+        /* Get DHR12R2 address */
+        tmpreg = (uint32_t)&hdac->Instance->DHR12R2;
+        break;
+      case DAC_ALIGN_12B_L:
+        /* Get DHR12L2 address */
+        tmpreg = (uint32_t)&hdac->Instance->DHR12L2;
+        break;
+      case DAC_ALIGN_8B_R:
+        /* Get DHR8R2 address */
+        tmpreg = (uint32_t)&hdac->Instance->DHR8R2;
+        break;
+      default:
+        break;
+    }
+  }
+#endif /* DAC_CHANNEL2_SUPPORT */
+
+  /* Enable the DMA Stream */
+  if (Channel == DAC_CHANNEL_1)
+  {
+    /* Enable the DAC DMA underrun interrupt */
+    __HAL_DAC_ENABLE_IT(hdac, DAC_IT_DMAUDR1);
+
+    /* Enable the DMA Stream */
+    status = HAL_DMA_Start_IT(hdac->DMA_Handle1, (uint32_t)pData, tmpreg, Length);
+  }
+#if defined(DAC_CHANNEL2_SUPPORT)
+  else
+  {
+    /* Enable the DAC DMA underrun interrupt */
+    __HAL_DAC_ENABLE_IT(hdac, DAC_IT_DMAUDR2);
+
+    /* Enable the DMA Stream */
+    status = HAL_DMA_Start_IT(hdac->DMA_Handle2, (uint32_t)pData, tmpreg, Length);
+  }
+#endif /* DAC_CHANNEL2_SUPPORT */
+
+  /* Process Unlocked */
+  __HAL_UNLOCK(hdac);
+
+  if (status == HAL_OK)
+  {
+    /* Enable the Peripheral */
+    __HAL_DAC_ENABLE(hdac, Channel);
+  }
+  else
+  {
+    hdac->ErrorCode |= HAL_DAC_ERROR_DMA;
+  }
+
+  /* Return function status */
+  return status;
+}
+
+/**
+  * @brief  Disables DAC and stop conversion of channel.
+  * @param  hdac pointer to a DAC_HandleTypeDef structure that contains
+  *         the configuration information for the specified DAC.
+  * @param  Channel The selected DAC channel.
+  *          This parameter can be one of the following values:
+  *            @arg DAC_CHANNEL_1: DAC Channel1 selected
+  *            @arg DAC_CHANNEL_2: DAC Channel2 selected
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_DAC_Stop_DMA(DAC_HandleTypeDef *hdac, uint32_t Channel)
+{
+  /* Check the parameters */
+  assert_param(IS_DAC_CHANNEL(Channel));
+
+  /* Disable the selected DAC channel DMA request */
+  hdac->Instance->CR &= ~(DAC_CR_DMAEN1 << (Channel & 0x10UL));
+
+  /* Disable the Peripheral */
+  __HAL_DAC_DISABLE(hdac, Channel);
+
+  /* Disable the DMA Stream */
+
+  /* Channel1 is used */
+  if (Channel == DAC_CHANNEL_1)
+  {
+    /* Disable the DMA Stream */
+    (void)HAL_DMA_Abort(hdac->DMA_Handle1);
+
+    /* Disable the DAC DMA underrun interrupt */
+    __HAL_DAC_DISABLE_IT(hdac, DAC_IT_DMAUDR1);
+  }
+#if defined(DAC_CHANNEL2_SUPPORT)
+  else /* Channel2 is used for */
+  {
+    /* Disable the DMA Stream */
+    (void)HAL_DMA_Abort(hdac->DMA_Handle2);
+
+    /* Disable the DAC DMA underrun interrupt */
+    __HAL_DAC_DISABLE_IT(hdac, DAC_IT_DMAUDR2);
+  }
+#endif /* DAC_CHANNEL2_SUPPORT */
+
+  /* Change DAC state */
+  hdac->State = HAL_DAC_STATE_READY;
+
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Handles DAC interrupt request
+  *         This function uses the interruption of DMA
+  *         underrun.
+  * @param  hdac pointer to a DAC_HandleTypeDef structure that contains
+  *         the configuration information for the specified DAC.
+  * @retval None
+  */
+void HAL_DAC_IRQHandler(DAC_HandleTypeDef *hdac)
+{
+  if (__HAL_DAC_GET_IT_SOURCE(hdac, DAC_IT_DMAUDR1))
+  {
+    /* Check underrun flag of DAC channel 1 */
+    if (__HAL_DAC_GET_FLAG(hdac, DAC_FLAG_DMAUDR1))
+    {
+      /* Change DAC state to error state */
+      hdac->State = HAL_DAC_STATE_ERROR;
+
+      /* Set DAC error code to channel1 DMA underrun error */
+      SET_BIT(hdac->ErrorCode, HAL_DAC_ERROR_DMAUNDERRUNCH1);
+
+      /* Clear the underrun flag */
+      __HAL_DAC_CLEAR_FLAG(hdac, DAC_FLAG_DMAUDR1);
+
+      /* Disable the selected DAC channel1 DMA request */
+      CLEAR_BIT(hdac->Instance->CR, DAC_CR_DMAEN1);
+
+      /* Error callback */
+#if (USE_HAL_DAC_REGISTER_CALLBACKS == 1)
+      hdac->DMAUnderrunCallbackCh1(hdac);
+#else
+      HAL_DAC_DMAUnderrunCallbackCh1(hdac);
+#endif /* USE_HAL_DAC_REGISTER_CALLBACKS */
+    }
+  }
+
+#if defined(DAC_CHANNEL2_SUPPORT)
+  if (__HAL_DAC_GET_IT_SOURCE(hdac, DAC_IT_DMAUDR2))
+  {
+    /* Check underrun flag of DAC channel 2 */
+    if (__HAL_DAC_GET_FLAG(hdac, DAC_FLAG_DMAUDR2))
+    {
+      /* Change DAC state to error state */
+      hdac->State = HAL_DAC_STATE_ERROR;
+
+      /* Set DAC error code to channel2 DMA underrun error */
+      SET_BIT(hdac->ErrorCode, HAL_DAC_ERROR_DMAUNDERRUNCH2);
+
+      /* Clear the underrun flag */
+      __HAL_DAC_CLEAR_FLAG(hdac, DAC_FLAG_DMAUDR2);
+
+      /* Disable the selected DAC channel2 DMA request */
+      CLEAR_BIT(hdac->Instance->CR, DAC_CR_DMAEN2);
+
+      /* Error callback */
+#if (USE_HAL_DAC_REGISTER_CALLBACKS == 1)
+      hdac->DMAUnderrunCallbackCh2(hdac);
+#else
+      HAL_DACEx_DMAUnderrunCallbackCh2(hdac);
+#endif /* USE_HAL_DAC_REGISTER_CALLBACKS */
+    }
+  }
+#endif /* DAC_CHANNEL2_SUPPORT */
+}
+
+/**
+  * @brief  Set the specified data holding register value for DAC channel.
+  * @param  hdac pointer to a DAC_HandleTypeDef structure that contains
+  *         the configuration information for the specified DAC.
+  * @param  Channel The selected DAC channel.
+  *          This parameter can be one of the following values:
+  *            @arg DAC_CHANNEL_1: DAC Channel1 selected
+  *            @arg DAC_CHANNEL_2: DAC Channel2 selected
+  * @param  Alignment Specifies the data alignment.
+  *          This parameter can be one of the following values:
+  *            @arg DAC_ALIGN_8B_R: 8bit right data alignment selected
+  *            @arg DAC_ALIGN_12B_L: 12bit left data alignment selected
+  *            @arg DAC_ALIGN_12B_R: 12bit right data alignment selected
+  * @param  Data Data to be loaded in the selected data holding register.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_DAC_SetValue(DAC_HandleTypeDef *hdac, uint32_t Channel, uint32_t Alignment, uint32_t Data)
+{
+  __IO uint32_t tmp = 0UL;
+
+  /* Check the parameters */
+  assert_param(IS_DAC_CHANNEL(Channel));
+  assert_param(IS_DAC_ALIGN(Alignment));
+  assert_param(IS_DAC_DATA(Data));
+
+  tmp = (uint32_t)hdac->Instance;
+  if (Channel == DAC_CHANNEL_1)
+  {
+    tmp += DAC_DHR12R1_ALIGNMENT(Alignment);
+  }
+#if defined(DAC_CHANNEL2_SUPPORT)
+  else
+  {
+    tmp += DAC_DHR12R2_ALIGNMENT(Alignment);
+  }
+#endif /* DAC_CHANNEL2_SUPPORT */
+
+  /* Set the DAC channel selected data holding register */
+  *(__IO uint32_t *) tmp = Data;
+
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Conversion complete callback in non-blocking mode for Channel1
+  * @param  hdac pointer to a DAC_HandleTypeDef structure that contains
+  *         the configuration information for the specified DAC.
+  * @retval None
+  */
+__weak void HAL_DAC_ConvCpltCallbackCh1(DAC_HandleTypeDef *hdac)
+{
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(hdac);
+
+  /* NOTE : This function should not be modified, when the callback is needed,
+            the HAL_DAC_ConvCpltCallbackCh1 could be implemented in the user file
+   */
+}
+
+/**
+  * @brief  Conversion half DMA transfer callback in non-blocking mode for Channel1
+  * @param  hdac pointer to a DAC_HandleTypeDef structure that contains
+  *         the configuration information for the specified DAC.
+  * @retval None
+  */
+__weak void HAL_DAC_ConvHalfCpltCallbackCh1(DAC_HandleTypeDef *hdac)
+{
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(hdac);
+
+  /* NOTE : This function should not be modified, when the callback is needed,
+            the HAL_DAC_ConvHalfCpltCallbackCh1 could be implemented in the user file
+   */
+}
+
+/**
+  * @brief  Error DAC callback for Channel1.
+  * @param  hdac pointer to a DAC_HandleTypeDef structure that contains
+  *         the configuration information for the specified DAC.
+  * @retval None
+  */
+__weak void HAL_DAC_ErrorCallbackCh1(DAC_HandleTypeDef *hdac)
+{
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(hdac);
+
+  /* NOTE : This function should not be modified, when the callback is needed,
+            the HAL_DAC_ErrorCallbackCh1 could be implemented in the user file
+   */
+}
+
+/**
+  * @brief  DMA underrun DAC callback for channel1.
+  * @param  hdac pointer to a DAC_HandleTypeDef structure that contains
+  *         the configuration information for the specified DAC.
+  * @retval None
+  */
+__weak void HAL_DAC_DMAUnderrunCallbackCh1(DAC_HandleTypeDef *hdac)
+{
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(hdac);
+
+  /* NOTE : This function should not be modified, when the callback is needed,
+            the HAL_DAC_DMAUnderrunCallbackCh1 could be implemented in the user file
+   */
+}
+
+/**
+  * @}
+  */
+
+/** @defgroup DAC_Exported_Functions_Group3 Peripheral Control functions
+  *  @brief    Peripheral Control functions
+  *
+@verbatim
+  ==============================================================================
+             ##### Peripheral Control functions #####
+  ==============================================================================
+    [..]  This section provides functions allowing to:
+      (+) Configure channels.
+      (+) Set the specified data holding register value for DAC channel.
+
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief  Returns the last data output value of the selected DAC channel.
+  * @param  hdac pointer to a DAC_HandleTypeDef structure that contains
+  *         the configuration information for the specified DAC.
+  * @param  Channel The selected DAC channel.
+  *          This parameter can be one of the following values:
+  *            @arg DAC_CHANNEL_1: DAC Channel1 selected
+  *            @arg DAC_CHANNEL_2: DAC Channel2 selected
+  * @retval The selected DAC channel data output value.
+  */
+uint32_t HAL_DAC_GetValue(DAC_HandleTypeDef *hdac, uint32_t Channel)
+{
+  uint32_t result = 0;
+
+  /* Check the parameters */
+  assert_param(IS_DAC_CHANNEL(Channel));
+
+  if (Channel == DAC_CHANNEL_1)
+  {
+    result = hdac->Instance->DOR1;
+  }
+#if defined(DAC_CHANNEL2_SUPPORT)
+  else
+  {
+    result = hdac->Instance->DOR2;
+  }
+#endif /* DAC_CHANNEL2_SUPPORT */
+  /* Returns the DAC channel data output register value */
+  return result;
+}
+
+/**
+  * @brief  Configures the selected DAC channel.
+  * @param  hdac pointer to a DAC_HandleTypeDef structure that contains
+  *         the configuration information for the specified DAC.
+  * @param  sConfig DAC configuration structure.
+  * @param  Channel The selected DAC channel.
+  *          This parameter can be one of the following values:
+  *            @arg DAC_CHANNEL_1: DAC Channel1 selected
+  *            @arg DAC_CHANNEL_2: DAC Channel2 selected
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_DAC_ConfigChannel(DAC_HandleTypeDef *hdac, DAC_ChannelConfTypeDef *sConfig, uint32_t Channel)
+{
+  uint32_t tmpreg1;
+  uint32_t tmpreg2;
+
+  /* Check the DAC parameters */
+  assert_param(IS_DAC_TRIGGER(sConfig->DAC_Trigger));
+  assert_param(IS_DAC_OUTPUT_BUFFER_STATE(sConfig->DAC_OutputBuffer));
+  assert_param(IS_DAC_CHANNEL(Channel));
+
+  /* Process locked */
+  __HAL_LOCK(hdac);
+
+  /* Change DAC state */
+  hdac->State = HAL_DAC_STATE_BUSY;
+
+  /* Get the DAC CR value */
+  tmpreg1 = hdac->Instance->CR;
+  /* Clear BOFFx, TENx, TSELx, WAVEx and MAMPx bits */
+  tmpreg1 &= ~(((uint32_t)(DAC_CR_MAMP1 | DAC_CR_WAVE1 | DAC_CR_TSEL1 | DAC_CR_TEN1 | DAC_CR_BOFF1)) << (Channel & 0x10UL));
+  /* Configure for the selected DAC channel: buffer output, trigger */
+  /* Set TSELx and TENx bits according to DAC_Trigger value */
+  /* Set BOFFx bit according to DAC_OutputBuffer value */
+  tmpreg2 = (sConfig->DAC_Trigger | sConfig->DAC_OutputBuffer);
+  /* Calculate CR register value depending on DAC_Channel */
+  tmpreg1 |= tmpreg2 << (Channel & 0x10UL);
+  /* Write to DAC CR */
+  hdac->Instance->CR = tmpreg1;
+  /* Disable wave generation */
+  CLEAR_BIT(hdac->Instance->CR, (DAC_CR_WAVE1 << (Channel & 0x10UL)));
+
+  /* Change DAC state */
+  hdac->State = HAL_DAC_STATE_READY;
+
+  /* Process unlocked */
+  __HAL_UNLOCK(hdac);
+
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @}
+  */
+
+/** @defgroup DAC_Exported_Functions_Group4 Peripheral State and Errors functions
+  *  @brief   Peripheral State and Errors functions
+  *
+@verbatim
+  ==============================================================================
+            ##### Peripheral State and Errors functions #####
+  ==============================================================================
+    [..]
+    This subsection provides functions allowing to
+      (+) Check the DAC state.
+      (+) Check the DAC Errors.
+
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief  return the DAC handle state
+  * @param  hdac pointer to a DAC_HandleTypeDef structure that contains
+  *         the configuration information for the specified DAC.
+  * @retval HAL state
+  */
+HAL_DAC_StateTypeDef HAL_DAC_GetState(DAC_HandleTypeDef *hdac)
+{
+  /* Return DAC handle state */
+  return hdac->State;
+}
+
+
+/**
+  * @brief  Return the DAC error code
+  * @param  hdac pointer to a DAC_HandleTypeDef structure that contains
+  *         the configuration information for the specified DAC.
+  * @retval DAC Error Code
+  */
+uint32_t HAL_DAC_GetError(DAC_HandleTypeDef *hdac)
+{
+  return hdac->ErrorCode;
+}
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/** @addtogroup DAC_Exported_Functions
+  * @{
+  */
+
+/** @addtogroup DAC_Exported_Functions_Group1
+  * @{
+  */
+#if (USE_HAL_DAC_REGISTER_CALLBACKS == 1)
+/**
+  * @brief  Register a User DAC Callback
+  *         To be used instead of the weak (surcharged) predefined callback
+  * @param  hdac DAC handle
+  * @param  CallbackID ID of the callback to be registered
+  *         This parameter can be one of the following values:
+  *          @arg @ref HAL_DAC_ERROR_INVALID_CALLBACK   DAC Error Callback ID
+  *          @arg @ref HAL_DAC_CH1_COMPLETE_CB_ID       DAC CH1 Complete Callback ID
+  *          @arg @ref HAL_DAC_CH1_HALF_COMPLETE_CB_ID  DAC CH1 Half Complete Callback ID
+  *          @arg @ref HAL_DAC_CH1_ERROR_ID             DAC CH1 Error Callback ID
+  *          @arg @ref HAL_DAC_CH1_UNDERRUN_CB_ID       DAC CH1 UnderRun Callback ID
+  *          @arg @ref HAL_DAC_CH2_COMPLETE_CB_ID       DAC CH2 Complete Callback ID
+  *          @arg @ref HAL_DAC_CH2_HALF_COMPLETE_CB_ID  DAC CH2 Half Complete Callback ID
+  *          @arg @ref HAL_DAC_CH2_ERROR_ID             DAC CH2 Error Callback ID
+  *          @arg @ref HAL_DAC_CH2_UNDERRUN_CB_ID       DAC CH2 UnderRun Callback ID
+  *          @arg @ref HAL_DAC_MSPINIT_CB_ID            DAC MSP Init Callback ID
+  *          @arg @ref HAL_DAC_MSPDEINIT_CB_ID          DAC MSP DeInit Callback ID
+  *
+  * @param  pCallback pointer to the Callback function
+  * @retval status
+  */
+HAL_StatusTypeDef HAL_DAC_RegisterCallback(DAC_HandleTypeDef *hdac, HAL_DAC_CallbackIDTypeDef CallbackID,
+                                           pDAC_CallbackTypeDef pCallback)
+{
+  HAL_StatusTypeDef status = HAL_OK;
+
+  if (pCallback == NULL)
+  {
+    /* Update the error code */
+    hdac->ErrorCode |= HAL_DAC_ERROR_INVALID_CALLBACK;
+    return HAL_ERROR;
+  }
+
+  /* Process locked */
+  __HAL_LOCK(hdac);
+
+  if (hdac->State == HAL_DAC_STATE_READY)
+  {
+    switch (CallbackID)
+    {
+      case HAL_DAC_CH1_COMPLETE_CB_ID :
+        hdac->ConvCpltCallbackCh1 = pCallback;
+        break;
+      case HAL_DAC_CH1_HALF_COMPLETE_CB_ID :
+        hdac->ConvHalfCpltCallbackCh1 = pCallback;
+        break;
+      case HAL_DAC_CH1_ERROR_ID :
+        hdac->ErrorCallbackCh1 = pCallback;
+        break;
+      case HAL_DAC_CH1_UNDERRUN_CB_ID :
+        hdac->DMAUnderrunCallbackCh1 = pCallback;
+        break;
+#if defined(DAC_CHANNEL2_SUPPORT)
+      case HAL_DAC_CH2_COMPLETE_CB_ID :
+        hdac->ConvCpltCallbackCh2 = pCallback;
+        break;
+      case HAL_DAC_CH2_HALF_COMPLETE_CB_ID :
+        hdac->ConvHalfCpltCallbackCh2 = pCallback;
+        break;
+      case HAL_DAC_CH2_ERROR_ID :
+        hdac->ErrorCallbackCh2 = pCallback;
+        break;
+      case HAL_DAC_CH2_UNDERRUN_CB_ID :
+        hdac->DMAUnderrunCallbackCh2 = pCallback;
+        break;
+#endif /* DAC_CHANNEL2_SUPPORT */
+      case HAL_DAC_MSPINIT_CB_ID :
+        hdac->MspInitCallback = pCallback;
+        break;
+      case HAL_DAC_MSPDEINIT_CB_ID :
+        hdac->MspDeInitCallback = pCallback;
+        break;
+      default :
+        /* Update the error code */
+        hdac->ErrorCode |= HAL_DAC_ERROR_INVALID_CALLBACK;
+        /* update return status */
+        status =  HAL_ERROR;
+        break;
+    }
+  }
+  else if (hdac->State == HAL_DAC_STATE_RESET)
+  {
+    switch (CallbackID)
+    {
+      case HAL_DAC_MSPINIT_CB_ID :
+        hdac->MspInitCallback = pCallback;
+        break;
+      case HAL_DAC_MSPDEINIT_CB_ID :
+        hdac->MspDeInitCallback = pCallback;
+        break;
+      default :
+        /* Update the error code */
+        hdac->ErrorCode |= HAL_DAC_ERROR_INVALID_CALLBACK;
+        /* update return status */
+        status =  HAL_ERROR;
+        break;
+    }
+  }
+  else
+  {
+    /* Update the error code */
+    hdac->ErrorCode |= HAL_DAC_ERROR_INVALID_CALLBACK;
+    /* update return status */
+    status =  HAL_ERROR;
+  }
+
+  /* Release Lock */
+  __HAL_UNLOCK(hdac);
+  return status;
+}
+
+/**
+  * @brief  Unregister a User DAC Callback
+  *         DAC Callback is redirected to the weak (surcharged) predefined callback
+  * @param  hdac DAC handle
+  * @param  CallbackID ID of the callback to be unregistered
+  *         This parameter can be one of the following values:
+  *          @arg @ref HAL_DAC_CH1_COMPLETE_CB_ID          DAC CH1 transfer Complete Callback ID
+  *          @arg @ref HAL_DAC_CH1_HALF_COMPLETE_CB_ID     DAC CH1 Half Complete Callback ID
+  *          @arg @ref HAL_DAC_CH1_ERROR_ID                DAC CH1 Error Callback ID
+  *          @arg @ref HAL_DAC_CH1_UNDERRUN_CB_ID          DAC CH1 UnderRun Callback ID
+  *          @arg @ref HAL_DAC_CH2_COMPLETE_CB_ID          DAC CH2 Complete Callback ID
+  *          @arg @ref HAL_DAC_CH2_HALF_COMPLETE_CB_ID     DAC CH2 Half Complete Callback ID
+  *          @arg @ref HAL_DAC_CH2_ERROR_ID                DAC CH2 Error Callback ID
+  *          @arg @ref HAL_DAC_CH2_UNDERRUN_CB_ID          DAC CH2 UnderRun Callback ID
+  *          @arg @ref HAL_DAC_MSPINIT_CB_ID               DAC MSP Init Callback ID
+  *          @arg @ref HAL_DAC_MSPDEINIT_CB_ID             DAC MSP DeInit Callback ID
+  *          @arg @ref HAL_DAC_ALL_CB_ID                   DAC All callbacks
+  * @retval status
+  */
+HAL_StatusTypeDef HAL_DAC_UnRegisterCallback(DAC_HandleTypeDef *hdac, HAL_DAC_CallbackIDTypeDef CallbackID)
+{
+  HAL_StatusTypeDef status = HAL_OK;
+
+  /* Process locked */
+  __HAL_LOCK(hdac);
+
+  if (hdac->State == HAL_DAC_STATE_READY)
+  {
+    switch (CallbackID)
+    {
+      case HAL_DAC_CH1_COMPLETE_CB_ID :
+        hdac->ConvCpltCallbackCh1 = HAL_DAC_ConvCpltCallbackCh1;
+        break;
+      case HAL_DAC_CH1_HALF_COMPLETE_CB_ID :
+        hdac->ConvHalfCpltCallbackCh1 = HAL_DAC_ConvHalfCpltCallbackCh1;
+        break;
+      case HAL_DAC_CH1_ERROR_ID :
+        hdac->ErrorCallbackCh1 = HAL_DAC_ErrorCallbackCh1;
+        break;
+      case HAL_DAC_CH1_UNDERRUN_CB_ID :
+        hdac->DMAUnderrunCallbackCh1 = HAL_DAC_DMAUnderrunCallbackCh1;
+        break;
+#if defined(DAC_CHANNEL2_SUPPORT)
+      case HAL_DAC_CH2_COMPLETE_CB_ID :
+        hdac->ConvCpltCallbackCh2 = HAL_DACEx_ConvCpltCallbackCh2;
+        break;
+      case HAL_DAC_CH2_HALF_COMPLETE_CB_ID :
+        hdac->ConvHalfCpltCallbackCh2 = HAL_DACEx_ConvHalfCpltCallbackCh2;
+        break;
+      case HAL_DAC_CH2_ERROR_ID :
+        hdac->ErrorCallbackCh2 = HAL_DACEx_ErrorCallbackCh2;
+        break;
+      case HAL_DAC_CH2_UNDERRUN_CB_ID :
+        hdac->DMAUnderrunCallbackCh2 = HAL_DACEx_DMAUnderrunCallbackCh2;
+        break;
+#endif /* DAC_CHANNEL2_SUPPORT */
+      case HAL_DAC_MSPINIT_CB_ID :
+        hdac->MspInitCallback = HAL_DAC_MspInit;
+        break;
+      case HAL_DAC_MSPDEINIT_CB_ID :
+        hdac->MspDeInitCallback = HAL_DAC_MspDeInit;
+        break;
+      case HAL_DAC_ALL_CB_ID :
+        hdac->ConvCpltCallbackCh1 = HAL_DAC_ConvCpltCallbackCh1;
+        hdac->ConvHalfCpltCallbackCh1 = HAL_DAC_ConvHalfCpltCallbackCh1;
+        hdac->ErrorCallbackCh1 = HAL_DAC_ErrorCallbackCh1;
+        hdac->DMAUnderrunCallbackCh1 = HAL_DAC_DMAUnderrunCallbackCh1;
+#if defined(DAC_CHANNEL2_SUPPORT)
+        hdac->ConvCpltCallbackCh2 = HAL_DACEx_ConvCpltCallbackCh2;
+        hdac->ConvHalfCpltCallbackCh2 = HAL_DACEx_ConvHalfCpltCallbackCh2;
+        hdac->ErrorCallbackCh2 = HAL_DACEx_ErrorCallbackCh2;
+        hdac->DMAUnderrunCallbackCh2 = HAL_DACEx_DMAUnderrunCallbackCh2;
+#endif /* DAC_CHANNEL2_SUPPORT */
+        hdac->MspInitCallback = HAL_DAC_MspInit;
+        hdac->MspDeInitCallback = HAL_DAC_MspDeInit;
+        break;
+      default :
+        /* Update the error code */
+        hdac->ErrorCode |= HAL_DAC_ERROR_INVALID_CALLBACK;
+        /* update return status */
+        status =  HAL_ERROR;
+        break;
+    }
+  }
+  else if (hdac->State == HAL_DAC_STATE_RESET)
+  {
+    switch (CallbackID)
+    {
+      case HAL_DAC_MSPINIT_CB_ID :
+        hdac->MspInitCallback = HAL_DAC_MspInit;
+        break;
+      case HAL_DAC_MSPDEINIT_CB_ID :
+        hdac->MspDeInitCallback = HAL_DAC_MspDeInit;
+        break;
+      default :
+        /* Update the error code */
+        hdac->ErrorCode |= HAL_DAC_ERROR_INVALID_CALLBACK;
+        /* update return status */
+        status =  HAL_ERROR;
+        break;
+    }
+  }
+  else
+  {
+    /* Update the error code */
+    hdac->ErrorCode |= HAL_DAC_ERROR_INVALID_CALLBACK;
+    /* update return status */
+    status =  HAL_ERROR;
+  }
+
+  /* Release Lock */
+  __HAL_UNLOCK(hdac);
+  return status;
+}
+#endif /* USE_HAL_DAC_REGISTER_CALLBACKS */
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/** @addtogroup DAC_Private_Functions
+  * @{
+  */
+
+/**
+  * @brief  DMA conversion complete callback.
+  * @param  hdma pointer to a DMA_HandleTypeDef structure that contains
+  *                the configuration information for the specified DMA module.
+  * @retval None
+  */
+void DAC_DMAConvCpltCh1(DMA_HandleTypeDef *hdma)
+{
+  DAC_HandleTypeDef *hdac = (DAC_HandleTypeDef *)((DMA_HandleTypeDef *)hdma)->Parent;
+
+#if (USE_HAL_DAC_REGISTER_CALLBACKS == 1)
+  hdac->ConvCpltCallbackCh1(hdac);
+#else
+  HAL_DAC_ConvCpltCallbackCh1(hdac);
+#endif /* USE_HAL_DAC_REGISTER_CALLBACKS */
+
+  hdac->State = HAL_DAC_STATE_READY;
+}
+
+/**
+  * @brief  DMA half transfer complete callback.
+  * @param  hdma pointer to a DMA_HandleTypeDef structure that contains
+  *                the configuration information for the specified DMA module.
+  * @retval None
+  */
+void DAC_DMAHalfConvCpltCh1(DMA_HandleTypeDef *hdma)
+{
+  DAC_HandleTypeDef *hdac = (DAC_HandleTypeDef *)((DMA_HandleTypeDef *)hdma)->Parent;
+  /* Conversion complete callback */
+#if (USE_HAL_DAC_REGISTER_CALLBACKS == 1)
+  hdac->ConvHalfCpltCallbackCh1(hdac);
+#else
+  HAL_DAC_ConvHalfCpltCallbackCh1(hdac);
+#endif  /* USE_HAL_DAC_REGISTER_CALLBACKS */
+}
+
+/**
+  * @brief  DMA error callback
+  * @param  hdma pointer to a DMA_HandleTypeDef structure that contains
+  *                the configuration information for the specified DMA module.
+  * @retval None
+  */
+void DAC_DMAErrorCh1(DMA_HandleTypeDef *hdma)
+{
+  DAC_HandleTypeDef *hdac = (DAC_HandleTypeDef *)((DMA_HandleTypeDef *)hdma)->Parent;
+
+  /* Set DAC error code to DMA error */
+  hdac->ErrorCode |= HAL_DAC_ERROR_DMA;
+
+#if (USE_HAL_DAC_REGISTER_CALLBACKS == 1)
+  hdac->ErrorCallbackCh1(hdac);
+#else
+  HAL_DAC_ErrorCallbackCh1(hdac);
+#endif /* USE_HAL_DAC_REGISTER_CALLBACKS */
+
+  hdac->State = HAL_DAC_STATE_READY;
+}
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+#endif /* DAC */
+
+#endif /* HAL_DAC_MODULE_ENABLED */
+
+/**
+  * @}
+  */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/Drivers/STM32F4xx_HAL_Driver/Src/stm32f4xx_hal_dac_ex.c
+++ b/Drivers/STM32F4xx_HAL_Driver/Src/stm32f4xx_hal_dac_ex.c
@@ -1,0 +1,496 @@
+/**
+  ******************************************************************************
+  * @file    stm32f4xx_hal_dac_ex.c
+  * @author  MCD Application Team
+  * @brief   Extended DAC HAL module driver.
+  *          This file provides firmware functions to manage the extended
+  *          functionalities of the DAC peripheral.
+  *
+  *
+  @verbatim
+  ==============================================================================
+                      ##### How to use this driver #####
+  ==============================================================================
+    [..]
+
+     *** Dual mode IO operation ***
+     ==============================
+     [..]
+      (+) When Dual mode is enabled (i.e. DAC Channel1 and Channel2 are used simultaneously) :
+          Use HAL_DACEx_DualGetValue() to get digital data to be converted and use
+          HAL_DACEx_DualSetValue() to set digital value to converted simultaneously in
+          Channel 1 and Channel 2.
+
+     *** Signal generation operation ***
+     ===================================
+     [..]
+      (+) Use HAL_DACEx_TriangleWaveGenerate() to generate Triangle signal.
+      (+) Use HAL_DACEx_NoiseWaveGenerate() to generate Noise signal.
+
+ @endverbatim
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; Copyright (c) 2016 STMicroelectronics.
+  * All rights reserved.</center></h2>
+  *
+  * This software component is licensed by ST under BSD 3-Clause license,
+  * the "License"; You may not use this file except in compliance with the
+  * License. You may obtain a copy of the License at:
+  *                        opensource.org/licenses/BSD-3-Clause
+  *
+  ******************************************************************************
+  */
+
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32f4xx_hal.h"
+
+/** @addtogroup STM32F4xx_HAL_Driver
+  * @{
+  */
+
+#ifdef HAL_DAC_MODULE_ENABLED
+
+#if defined(DAC)
+
+/** @defgroup DACEx DACEx
+  * @brief DAC Extended HAL module driver
+  * @{
+  */
+
+/* Private typedef -----------------------------------------------------------*/
+/* Private define ------------------------------------------------------------*/
+/* Private macro -------------------------------------------------------------*/
+/* Private variables ---------------------------------------------------------*/
+/* Private function prototypes -----------------------------------------------*/
+/* Exported functions --------------------------------------------------------*/
+
+/** @defgroup DACEx_Exported_Functions DACEx Exported Functions
+  * @{
+  */
+
+/** @defgroup DACEx_Exported_Functions_Group2 IO operation functions
+  *  @brief    Extended IO operation functions
+  *
+@verbatim
+  ==============================================================================
+                 ##### Extended features functions #####
+  ==============================================================================
+    [..]  This section provides functions allowing to:
+      (+) Start conversion.
+      (+) Stop conversion.
+      (+) Start conversion and enable DMA transfer.
+      (+) Stop conversion and disable DMA transfer.
+      (+) Get result of conversion.
+      (+) Get result of dual mode conversion.
+
+@endverbatim
+  * @{
+  */
+
+#if defined(DAC_CHANNEL2_SUPPORT)
+/**
+  * @brief  Enables DAC and starts conversion of both channels.
+  * @param  hdac pointer to a DAC_HandleTypeDef structure that contains
+  *         the configuration information for the specified DAC.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_DACEx_DualStart(DAC_HandleTypeDef *hdac)
+{
+  uint32_t tmp_swtrig = 0UL;
+
+
+  /* Process locked */
+  __HAL_LOCK(hdac);
+
+  /* Change DAC state */
+  hdac->State = HAL_DAC_STATE_BUSY;
+
+  /* Enable the Peripheral */
+  __HAL_DAC_ENABLE(hdac, DAC_CHANNEL_1);
+  __HAL_DAC_ENABLE(hdac, DAC_CHANNEL_2);
+
+  /* Check if software trigger enabled */
+  if ((hdac->Instance->CR & (DAC_CR_TEN1 | DAC_CR_TSEL1)) == DAC_TRIGGER_SOFTWARE)
+  {
+    tmp_swtrig |= DAC_SWTRIGR_SWTRIG1;
+  }
+  if ((hdac->Instance->CR & (DAC_CR_TEN2 | DAC_CR_TSEL2)) == (DAC_TRIGGER_SOFTWARE << (DAC_CHANNEL_2 & 0x10UL)))
+  {
+    tmp_swtrig |= DAC_SWTRIGR_SWTRIG2;
+  }
+  /* Enable the selected DAC software conversion*/
+  SET_BIT(hdac->Instance->SWTRIGR, tmp_swtrig);
+
+  /* Change DAC state */
+  hdac->State = HAL_DAC_STATE_READY;
+
+  /* Process unlocked */
+  __HAL_UNLOCK(hdac);
+
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Disables DAC and stop conversion of both channels.
+  * @param  hdac pointer to a DAC_HandleTypeDef structure that contains
+  *         the configuration information for the specified DAC.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_DACEx_DualStop(DAC_HandleTypeDef *hdac)
+{
+
+  /* Disable the Peripheral */
+  __HAL_DAC_DISABLE(hdac, DAC_CHANNEL_1);
+  __HAL_DAC_DISABLE(hdac, DAC_CHANNEL_2);
+
+  /* Change DAC state */
+  hdac->State = HAL_DAC_STATE_READY;
+
+  /* Return function status */
+  return HAL_OK;
+}
+#endif /* DAC_CHANNEL2_SUPPORT */
+
+/**
+  * @brief  Enable or disable the selected DAC channel wave generation.
+  * @param  hdac pointer to a DAC_HandleTypeDef structure that contains
+  *         the configuration information for the specified DAC.
+  * @param  Channel The selected DAC channel.
+  *          This parameter can be one of the following values:
+  *            @arg DAC_CHANNEL_1: DAC Channel1 selected
+  *            @arg DAC_CHANNEL_2: DAC Channel2 selected
+  * @param  Amplitude Select max triangle amplitude.
+  *          This parameter can be one of the following values:
+  *            @arg DAC_TRIANGLEAMPLITUDE_1: Select max triangle amplitude of 1
+  *            @arg DAC_TRIANGLEAMPLITUDE_3: Select max triangle amplitude of 3
+  *            @arg DAC_TRIANGLEAMPLITUDE_7: Select max triangle amplitude of 7
+  *            @arg DAC_TRIANGLEAMPLITUDE_15: Select max triangle amplitude of 15
+  *            @arg DAC_TRIANGLEAMPLITUDE_31: Select max triangle amplitude of 31
+  *            @arg DAC_TRIANGLEAMPLITUDE_63: Select max triangle amplitude of 63
+  *            @arg DAC_TRIANGLEAMPLITUDE_127: Select max triangle amplitude of 127
+  *            @arg DAC_TRIANGLEAMPLITUDE_255: Select max triangle amplitude of 255
+  *            @arg DAC_TRIANGLEAMPLITUDE_511: Select max triangle amplitude of 511
+  *            @arg DAC_TRIANGLEAMPLITUDE_1023: Select max triangle amplitude of 1023
+  *            @arg DAC_TRIANGLEAMPLITUDE_2047: Select max triangle amplitude of 2047
+  *            @arg DAC_TRIANGLEAMPLITUDE_4095: Select max triangle amplitude of 4095
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_DACEx_TriangleWaveGenerate(DAC_HandleTypeDef *hdac, uint32_t Channel, uint32_t Amplitude)
+{
+  /* Check the parameters */
+  assert_param(IS_DAC_CHANNEL(Channel));
+  assert_param(IS_DAC_LFSR_UNMASK_TRIANGLE_AMPLITUDE(Amplitude));
+
+  /* Process locked */
+  __HAL_LOCK(hdac);
+
+  /* Change DAC state */
+  hdac->State = HAL_DAC_STATE_BUSY;
+
+  /* Enable the triangle wave generation for the selected DAC channel */
+  MODIFY_REG(hdac->Instance->CR, ((DAC_CR_WAVE1) | (DAC_CR_MAMP1)) << (Channel & 0x10UL),
+             (DAC_CR_WAVE1_1 | Amplitude) << (Channel & 0x10UL));
+
+  /* Change DAC state */
+  hdac->State = HAL_DAC_STATE_READY;
+
+  /* Process unlocked */
+  __HAL_UNLOCK(hdac);
+
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Enable or disable the selected DAC channel wave generation.
+  * @param  hdac pointer to a DAC_HandleTypeDef structure that contains
+  *         the configuration information for the specified DAC.
+  * @param  Channel The selected DAC channel.
+  *          This parameter can be one of the following values:
+  *            @arg DAC_CHANNEL_1: DAC Channel1 selected
+  *            @arg DAC_CHANNEL_2: DAC Channel2 selected
+  * @param  Amplitude Unmask DAC channel LFSR for noise wave generation.
+  *          This parameter can be one of the following values:
+  *            @arg DAC_LFSRUNMASK_BIT0: Unmask DAC channel LFSR bit0 for noise wave generation
+  *            @arg DAC_LFSRUNMASK_BITS1_0: Unmask DAC channel LFSR bit[1:0] for noise wave generation
+  *            @arg DAC_LFSRUNMASK_BITS2_0: Unmask DAC channel LFSR bit[2:0] for noise wave generation
+  *            @arg DAC_LFSRUNMASK_BITS3_0: Unmask DAC channel LFSR bit[3:0] for noise wave generation
+  *            @arg DAC_LFSRUNMASK_BITS4_0: Unmask DAC channel LFSR bit[4:0] for noise wave generation
+  *            @arg DAC_LFSRUNMASK_BITS5_0: Unmask DAC channel LFSR bit[5:0] for noise wave generation
+  *            @arg DAC_LFSRUNMASK_BITS6_0: Unmask DAC channel LFSR bit[6:0] for noise wave generation
+  *            @arg DAC_LFSRUNMASK_BITS7_0: Unmask DAC channel LFSR bit[7:0] for noise wave generation
+  *            @arg DAC_LFSRUNMASK_BITS8_0: Unmask DAC channel LFSR bit[8:0] for noise wave generation
+  *            @arg DAC_LFSRUNMASK_BITS9_0: Unmask DAC channel LFSR bit[9:0] for noise wave generation
+  *            @arg DAC_LFSRUNMASK_BITS10_0: Unmask DAC channel LFSR bit[10:0] for noise wave generation
+  *            @arg DAC_LFSRUNMASK_BITS11_0: Unmask DAC channel LFSR bit[11:0] for noise wave generation
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_DACEx_NoiseWaveGenerate(DAC_HandleTypeDef *hdac, uint32_t Channel, uint32_t Amplitude)
+{
+  /* Check the parameters */
+  assert_param(IS_DAC_CHANNEL(Channel));
+  assert_param(IS_DAC_LFSR_UNMASK_TRIANGLE_AMPLITUDE(Amplitude));
+
+  /* Process locked */
+  __HAL_LOCK(hdac);
+
+  /* Change DAC state */
+  hdac->State = HAL_DAC_STATE_BUSY;
+
+  /* Enable the noise wave generation for the selected DAC channel */
+  MODIFY_REG(hdac->Instance->CR, ((DAC_CR_WAVE1) | (DAC_CR_MAMP1)) << (Channel & 0x10UL),
+             (DAC_CR_WAVE1_0 | Amplitude) << (Channel & 0x10UL));
+
+  /* Change DAC state */
+  hdac->State = HAL_DAC_STATE_READY;
+
+  /* Process unlocked */
+  __HAL_UNLOCK(hdac);
+
+  /* Return function status */
+  return HAL_OK;
+}
+
+#if defined(DAC_CHANNEL2_SUPPORT)
+/**
+  * @brief  Set the specified data holding register value for dual DAC channel.
+  * @param  hdac pointer to a DAC_HandleTypeDef structure that contains
+  *               the configuration information for the specified DAC.
+  * @param  Alignment Specifies the data alignment for dual channel DAC.
+  *          This parameter can be one of the following values:
+  *            DAC_ALIGN_8B_R: 8bit right data alignment selected
+  *            DAC_ALIGN_12B_L: 12bit left data alignment selected
+  *            DAC_ALIGN_12B_R: 12bit right data alignment selected
+  * @param  Data1 Data for DAC Channel1 to be loaded in the selected data holding register.
+  * @param  Data2 Data for DAC Channel2 to be loaded in the selected data  holding register.
+  * @note   In dual mode, a unique register access is required to write in both
+  *          DAC channels at the same time.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_DACEx_DualSetValue(DAC_HandleTypeDef *hdac, uint32_t Alignment, uint32_t Data1, uint32_t Data2)
+{
+  uint32_t data;
+  uint32_t tmp;
+
+  /* Check the parameters */
+  assert_param(IS_DAC_ALIGN(Alignment));
+  assert_param(IS_DAC_DATA(Data1));
+  assert_param(IS_DAC_DATA(Data2));
+
+  /* Calculate and set dual DAC data holding register value */
+  if (Alignment == DAC_ALIGN_8B_R)
+  {
+    data = ((uint32_t)Data2 << 8U) | Data1;
+  }
+  else
+  {
+    data = ((uint32_t)Data2 << 16U) | Data1;
+  }
+
+  tmp = (uint32_t)hdac->Instance;
+  tmp += DAC_DHR12RD_ALIGNMENT(Alignment);
+
+  /* Set the dual DAC selected data holding register */
+  *(__IO uint32_t *)tmp = data;
+
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Conversion complete callback in non-blocking mode for Channel2.
+  * @param  hdac pointer to a DAC_HandleTypeDef structure that contains
+  *         the configuration information for the specified DAC.
+  * @retval None
+  */
+__weak void HAL_DACEx_ConvCpltCallbackCh2(DAC_HandleTypeDef *hdac)
+{
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(hdac);
+
+  /* NOTE : This function should not be modified, when the callback is needed,
+            the HAL_DACEx_ConvCpltCallbackCh2 could be implemented in the user file
+   */
+}
+
+/**
+  * @brief  Conversion half DMA transfer callback in non-blocking mode for Channel2.
+  * @param  hdac pointer to a DAC_HandleTypeDef structure that contains
+  *         the configuration information for the specified DAC.
+  * @retval None
+  */
+__weak void HAL_DACEx_ConvHalfCpltCallbackCh2(DAC_HandleTypeDef *hdac)
+{
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(hdac);
+
+  /* NOTE : This function should not be modified, when the callback is needed,
+            the HAL_DACEx_ConvHalfCpltCallbackCh2 could be implemented in the user file
+   */
+}
+
+/**
+  * @brief  Error DAC callback for Channel2.
+  * @param  hdac pointer to a DAC_HandleTypeDef structure that contains
+  *         the configuration information for the specified DAC.
+  * @retval None
+  */
+__weak void HAL_DACEx_ErrorCallbackCh2(DAC_HandleTypeDef *hdac)
+{
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(hdac);
+
+  /* NOTE : This function should not be modified, when the callback is needed,
+            the HAL_DACEx_ErrorCallbackCh2 could be implemented in the user file
+   */
+}
+
+/**
+  * @brief  DMA underrun DAC callback for Channel2.
+  * @param  hdac pointer to a DAC_HandleTypeDef structure that contains
+  *         the configuration information for the specified DAC.
+  * @retval None
+  */
+__weak void HAL_DACEx_DMAUnderrunCallbackCh2(DAC_HandleTypeDef *hdac)
+{
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(hdac);
+
+  /* NOTE : This function should not be modified, when the callback is needed,
+            the HAL_DACEx_DMAUnderrunCallbackCh2 could be implemented in the user file
+   */
+}
+#endif /* DAC_CHANNEL2_SUPPORT */
+
+
+/**
+  * @}
+  */
+
+/** @defgroup DACEx_Exported_Functions_Group3 Peripheral Control functions
+  *  @brief    Extended Peripheral Control functions
+  *
+@verbatim
+  ==============================================================================
+             ##### Peripheral Control functions #####
+  ==============================================================================
+    [..]  This section provides functions allowing to:
+      (+) Set the specified data holding register value for DAC channel.
+
+@endverbatim
+  * @{
+  */
+
+#if defined(DAC_CHANNEL2_SUPPORT)
+/**
+  * @brief  Return the last data output value of the selected DAC channel.
+  * @param  hdac pointer to a DAC_HandleTypeDef structure that contains
+  *         the configuration information for the specified DAC.
+  * @retval The selected DAC channel data output value.
+  */
+uint32_t HAL_DACEx_DualGetValue(DAC_HandleTypeDef *hdac)
+{
+  uint32_t tmp = 0UL;
+
+  tmp |= hdac->Instance->DOR1;
+
+  tmp |= hdac->Instance->DOR2 << 16UL;
+
+  /* Returns the DAC channel data output register value */
+  return tmp;
+}
+#endif /* DAC_CHANNEL2_SUPPORT */
+
+/**
+  * @}
+  */
+/**
+  * @}
+  */
+
+/* Private functions ---------------------------------------------------------*/
+/** @defgroup DACEx_Private_Functions DACEx private functions
+  *  @brief    Extended private functions
+  * @{
+  */
+
+#if defined(DAC_CHANNEL2_SUPPORT)
+/**
+  * @brief  DMA conversion complete callback.
+  * @param  hdma pointer to a DMA_HandleTypeDef structure that contains
+  *                the configuration information for the specified DMA module.
+  * @retval None
+  */
+void DAC_DMAConvCpltCh2(DMA_HandleTypeDef *hdma)
+{
+  DAC_HandleTypeDef *hdac = (DAC_HandleTypeDef *)((DMA_HandleTypeDef *)hdma)->Parent;
+
+#if (USE_HAL_DAC_REGISTER_CALLBACKS == 1)
+  hdac->ConvCpltCallbackCh2(hdac);
+#else
+  HAL_DACEx_ConvCpltCallbackCh2(hdac);
+#endif /* USE_HAL_DAC_REGISTER_CALLBACKS */
+
+  hdac->State = HAL_DAC_STATE_READY;
+}
+
+/**
+  * @brief  DMA half transfer complete callback.
+  * @param  hdma pointer to a DMA_HandleTypeDef structure that contains
+  *                the configuration information for the specified DMA module.
+  * @retval None
+  */
+void DAC_DMAHalfConvCpltCh2(DMA_HandleTypeDef *hdma)
+{
+  DAC_HandleTypeDef *hdac = (DAC_HandleTypeDef *)((DMA_HandleTypeDef *)hdma)->Parent;
+  /* Conversion complete callback */
+#if (USE_HAL_DAC_REGISTER_CALLBACKS == 1)
+  hdac->ConvHalfCpltCallbackCh2(hdac);
+#else
+  HAL_DACEx_ConvHalfCpltCallbackCh2(hdac);
+#endif /* USE_HAL_DAC_REGISTER_CALLBACKS */
+}
+
+/**
+  * @brief  DMA error callback.
+  * @param  hdma pointer to a DMA_HandleTypeDef structure that contains
+  *                the configuration information for the specified DMA module.
+  * @retval None
+  */
+void DAC_DMAErrorCh2(DMA_HandleTypeDef *hdma)
+{
+  DAC_HandleTypeDef *hdac = (DAC_HandleTypeDef *)((DMA_HandleTypeDef *)hdma)->Parent;
+
+  /* Set DAC error code to DMA error */
+  hdac->ErrorCode |= HAL_DAC_ERROR_DMA;
+
+#if (USE_HAL_DAC_REGISTER_CALLBACKS == 1)
+  hdac->ErrorCallbackCh2(hdac);
+#else
+  HAL_DACEx_ErrorCallbackCh2(hdac);
+#endif /* USE_HAL_DAC_REGISTER_CALLBACKS */
+
+  hdac->State = HAL_DAC_STATE_READY;
+}
+#endif /* DAC_CHANNEL2_SUPPORT */
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+#endif /* DAC */
+
+#endif /* HAL_DAC_MODULE_ENABLED */
+
+/**
+  * @}
+  */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/Inc/btt_skr_2.0_dac_map.h
+++ b/Inc/btt_skr_2.0_dac_map.h
@@ -1,0 +1,190 @@
+/*
+  btt_skr_2.0_map.h - driver code for STM32F407 ARM processors
+
+  Part of grblHAL
+
+  Copyright (c) 2021 fitch22
+
+  Grbl is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  Grbl is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with Grbl.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#if N_ABC_MOTORS > 2
+#error "BTT SKR-2 supports 5 motors max."
+#endif
+
+#if TRINAMIC_ENABLE && N_GANGED > 0
+#error "BTT SKR-2 does not support ganged motors with Trinamic drivers."
+#endif
+
+#if !defined(STM32F407xx) || HSE_VALUE != 8000000
+#error "This board has STM32F407 processor with a 8MHz crystal, select a corresponding build!"
+#endif
+
+#define BOARD_NAME "BTT SKR-2 (DAC)"
+#define HAS_BOARD_INIT
+
+#define I2C_PORT 1      // GPIOB, SCL_PIN = 8, SDA_PIN = 9
+//#define I2C1_ALT_PINMAP // GPIOB, SCL_PIN = 6, SDA_PIN = 7
+
+// If we want to debug, we need to use USART1
+#if defined(DEBUG) && defined(USB_SERIAL_CDC)
+#undef USB_SERIAL_CDC
+#endif
+
+// Define step pulse output pins.
+#define X_STEP_PORT                 GPIOE
+#define X_STEP_PIN                  2                   // X
+#define Y_STEP_PORT                 GPIOD
+#define Y_STEP_PIN                  5                   // Y
+#define Z_STEP_PORT                 GPIOA
+#define Z_STEP_PIN                  15                  // Z
+#define STEP_OUTMODE                GPIO_BITBAND
+//#define STEP_PINMODE                PINMODE_OD // Uncomment for open drain outputs
+
+// Define step direction output pins.
+#define X_DIRECTION_PORT            GPIOE
+#define X_DIRECTION_PIN             1
+#define Y_DIRECTION_PORT            GPIOD
+#define Y_DIRECTION_PIN             4
+#define Z_DIRECTION_PORT            GPIOA
+#define Z_DIRECTION_PIN             8
+#define DIRECTION_OUTMODE           GPIO_BITBAND
+//#define DIRECTION_PINMODE           PINMODE_OD // Uncomment for open drain outputs
+
+// Define stepper driver enable/disable output pin.
+#define X_ENABLE_PORT               GPIOE
+#define X_ENABLE_PIN                3
+#define Y_ENABLE_PORT               GPIOD
+#define Y_ENABLE_PIN                6
+#define Z_ENABLE_PORT               GPIOD
+#define Z_ENABLE_PIN                1
+//#define STEPPERS_ENABLE_PINMODE   PINMODE_OD // Uncomment for open drain outputs
+
+// Define homing/hard limit switch input pins.
+#define X_LIMIT_PORT                GPIOC
+#define X_LIMIT_PIN                 1                           // X- Limit
+#define Y_LIMIT_PORT                GPIOC
+#define Y_LIMIT_PIN                 3                           // Y- Limit
+#define Z_LIMIT_PORT                GPIOC
+#define Z_LIMIT_PIN                 0                           // Z- Limit
+#define LIMIT_INMODE                GPIO_BITBAND
+
+// Define ganged axis or A axis step pulse and step direction output pins.
+#if N_ABC_MOTORS > 0
+#define M3_AVAILABLE                // E0
+#define M3_STEP_PORT                GPIOD
+#define M3_STEP_PIN                 15
+#define M3_DIRECTION_PORT           GPIOD
+#define M3_DIRECTION_PIN            14
+#define M3_LIMIT_PORT               GPIOC
+#define M3_LIMIT_PIN                2
+#define M3_ENABLE_PORT              GPIOC
+#define M3_ENABLE_PIN               7
+#endif
+
+// Define ganged axis or B axis step pulse and step direction output pins.
+#if N_ABC_MOTORS == 2
+#define M4_AVAILABLE                // E1
+#define M4_STEP_PORT                GPIOD
+#define M4_STEP_PIN                 11
+#define M4_DIRECTION_PORT           GPIOD
+#define M4_DIRECTION_PIN            10
+// The normal limit pin for E1 is PCA0, but bit 0 already has an interrupt (Z_LIMIT_PIN).
+// PC15 is normally used for PWRDET but is used for M4_LIMIT_PIN instead.
+// If using TMC drivers, jumper from PWRDET connector pin 3 to DIAG pin on driver.
+#define M4_LIMIT_PORT               GPIOC                       // orig GPIOA
+#define M4_LIMIT_PIN                15                          // orig 0
+#define M4_ENABLE_PORT              GPIOD
+#define M4_ENABLE_PIN               13
+#endif
+
+  // Define spindle enable and spindle direction output pins.
+#define SPINDLE_ENABLE_PORT         GPIOB
+#define SPINDLE_ENABLE_PIN          6                           // FAN1
+#define SPINDLE_DIRECTION_PORT      GPIOB
+#define SPINDLE_DIRECTION_PIN       5                           // FAN2
+
+// Define spindle PWM output pin.
+#define SPINDLE_PWM_PORT_BASE       GPIOB_BASE
+#define SPINDLE_PWM_PIN             0                           // EXP1 - PB0, pin 2
+
+// Define flood and mist coolant enable output pins.
+#define COOLANT_FLOOD_PORT          GPIOB
+#define COOLANT_FLOOD_PIN           3                           // HEAT0
+#define COOLANT_MIST_PORT           GPIOB
+#define COOLANT_MIST_PIN            4                           // HEAT1
+
+// Define user-control controls (cycle start, reset, feed hold) input pins.
+// These are all available on EXP2 along with electrical RESET* (EXP2-8)
+#define CONTROL_PORT                GPIOE
+#define RESET_PIN                   10                          // Exp1-5
+#define FEED_HOLD_PIN               11                          // Exp1-6
+#define CYCLE_START_PIN             12                          // Exp1-7
+
+#if SAFETY_DOOR_ENABLE
+#define SAFETY_DOOR_PORT            GPIOE
+#define SAFETY_DOOR_PIN             13                          // EXP1-8
+#endif
+#define CONTROL_INMODE              GPIO_BITBAND
+
+// Define probe switch input pin.
+#define PROBE_PORT                  GPIOE
+#define PROBE_PIN                   5                           // Servos
+
+// XXXXX
+// SKR-2 has SD/MMC interface and does not work in SPI mode
+#if SDCARD_ENABLE
+#error "SD SDIO/MMC interface does not support SPI."
+#endif
+
+// The BTT SKR-2 uses software SPI
+// MISO pin is also SWCLK from JTAG port, so can't debug with Trinamic SPI drivers:-(
+#define TRINAMIC_MOSI_PORT          GPIOE
+#define TRINAMIC_MOSI_PIN           14
+#define TRINAMIC_SCK_PORT           GPIOE
+#define TRINAMIC_SCK_PIN            15
+
+// BigTreeTech used PA14 (SWCLK) as MOT_MISO.
+// For debugging, change this to PA6 (on EXP2) and jumper directly to MISO pins on TMC2130s.
+#ifdef DEBUG
+#define TRINAMIC_MISO_PORT          GPIOE
+#define TRINAMIC_MISO_PIN           7		// temporary EXP2-3 to use while debugging.  real one is PA14
+#else
+#define TRINAMIC_MISO_PORT          GPIOA
+#define TRINAMIC_MISO_PIN           14
+#endif
+
+// The CS pins are also the UART pins for 1 wire serial Trinamic drivers (2208, 2209)
+#define MOTOR_CSX_PORT              GPIOE
+#define MOTOR_CSX_PIN               0
+#define MOTOR_CSY_PORT              GPIOD
+#define MOTOR_CSY_PIN               3
+#define MOTOR_CSZ_PORT              GPIOD
+#define MOTOR_CSZ_PIN               0
+
+#ifdef  M3_AVAILABLE
+#define MOTOR_CSM3_PORT             GPIOC
+#define MOTOR_CSM3_PIN              6
+#endif
+
+#ifdef  M4_AVAILABLE
+#define MOTOR_CSM4_PORT             GPIOD
+#define MOTOR_CSM4_PIN              12
+#endif
+
+// Safe Power Control
+#define STEPPERS_POWER_PORT         GPIOC
+#define STEPPERS_POWER_PIN          13
+
+// EOF

--- a/Inc/driver.h
+++ b/Inc/driver.h
@@ -119,6 +119,8 @@
   #include "btt_skr_pro_v1_1_map.h"
 #elif defined(BOARD_BTT_SKR_20)
   #include "btt_skr_2.0_map.h"
+#elif defined(BOARD_BTT_SKR_20_DAC)
+  #include "btt_skr_2.0_dac_map.h"
 #elif defined(BOARD_PROTONEER_3XX)
   #include "protoneer_3.xx_map.h"
 #elif defined(BOARD_GENERIC_UNO)

--- a/Inc/my_machine.h
+++ b/Inc/my_machine.h
@@ -32,6 +32,7 @@
 //#define BOARD_BTT_SKR_PRO_1_1 // F407 based 3D Printer board
 //#define BOARD_BTT_SKR_PRO_1_2 // F407 based 3D Printer board
 //#define BOARD_BTT_SKR_20      // F407 based 3D Printer board
+//#define BOARD_BTT_SKR_20_DAC  // F407 based 3D Printer board, uses analog output (DAC) for spindle speed control
 //#define BOARD_MY_MACHINE      // Add my_machine_map.h before enabling this!
 
 // WARNING: BOARD_BTT_SKR_20 may fry your Trinamic drivers due to bad hardware design.

--- a/Inc/stm32f4xx_hal_conf.h
+++ b/Inc/stm32f4xx_hal_conf.h
@@ -41,7 +41,7 @@
 /* #define HAL_CAN_MODULE_ENABLED   */
 /* #define HAL_CRC_MODULE_ENABLED   */
 /* #define HAL_CRYP_MODULE_ENABLED   */
-/* #define HAL_DAC_MODULE_ENABLED   */
+#define HAL_DAC_MODULE_ENABLED
 /* #define HAL_DCMI_MODULE_ENABLED   */
 /* #define HAL_DMA2D_MODULE_ENABLED   */
 /* #define HAL_ETH_MODULE_ENABLED   */


### PR DESCRIPTION
Enabled HAL_DAC_MODULE_ENABLED in stm32f4xx_hal_conf.h.
Added new btt_skr_2.0_dac_map.h to be used with analog output (DAC).
Added new board type to select new map file in driver.h.
Added new board type in my_machine.h.
Added #if/#endif guards in btt_skr_2.0.c to work with and without analog outputs.