### PR TITLE
Fixing btt skr pro 1.1 build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,8 +25,8 @@ $RECYCLE.BIN/
 .settings
 
 # Build folder
-
 build
+.pio/
 
 #
 # =========================

--- a/Inc/btt_skr_pro_v1_1_map.h
+++ b/Inc/btt_skr_pro_v1_1_map.h
@@ -131,8 +131,8 @@
 #define COOLANT_MIST_PIN            14                          // HEAT1
 
 // Define user-control controls (cycle start, reset, feed hold) input pins.
-#define RESET_PORT                  GPIOG
-#define RESET_PIN                   4                           // E0 Limit
+#define RESET_PORT                  GPIOE
+#define RESET_PIN                   15                          // E0 Limit
 #define FEED_HOLD_PORT              GPIOD
 #define FEED_HOLD_PIN               11                          // E1 Limit
 #define CYCLE_START_PORT            GPIOG

--- a/Inc/btt_skr_pro_v1_1_map.h
+++ b/Inc/btt_skr_pro_v1_1_map.h
@@ -136,7 +136,7 @@
 #define FEED_HOLD_PORT              GPIOD
 #define FEED_HOLD_PIN               11                          // E1 Limit
 #define CYCLE_START_PORT            GPIOG
-#define CYCLE_START_PIN             2                           // E2 Limit
+#define CYCLE_START_PIN             5                           // E2 Limit
 #if SAFETY_DOOR_ENABLE
 #define SAFETY_DOOR_PORT            GPIOG
 #define SAFETY_DOOR_PIN             6                           // EXP1 PG4

--- a/Inc/btt_skr_pro_v1_1_map.h
+++ b/Inc/btt_skr_pro_v1_1_map.h
@@ -83,7 +83,7 @@
 #define M3_DIRECTION_PORT           GPIOA
 #define M3_DIRECTION_PIN            0
 #define M3_LIMIT_PORT               GPIOE
-#define M3_LIMIT_PIN                10
+#define M3_LIMIT_PIN                15
 #define M3_ENABLE_PORT              GPIOC
 #define M3_ENABLE_PIN               3
 #endif
@@ -96,7 +96,7 @@
 #define M4_DIRECTION_PORT           GPIOE
 #define M4_DIRECTION_PIN            7
 #define M4_LIMIT_PORT               GPIOE
-#define M4_LIMIT_PIN                19
+#define M4_LIMIT_PIN                10
 #define M4_ENABLE_PORT              GPIOA
 #define M4_ENABLE_PIN               3
 #endif
@@ -131,12 +131,12 @@
 #define COOLANT_MIST_PIN            14                          // HEAT1
 
 // Define user-control controls (cycle start, reset, feed hold) input pins.
-#define RESET_PORT                  GPIOE
-#define RESET_PIN                   15                          // E0 Limit
-#define FEED_HOLD_PORT              GPIOD
-#define FEED_HOLD_PIN               11                          // E1 Limit
-#define CYCLE_START_PORT            GPIOG
-#define CYCLE_START_PIN             5                           // E2 Limit
+#define RESET_PORT                  GPIOF
+#define RESET_PIN                   13                          // EXP2 PF13
+#define FEED_HOLD_PORT              GPIOF
+#define FEED_HOLD_PIN               11                          // EXP2 PF11
+#define CYCLE_START_PORT            GPIOB
+#define CYCLE_START_PIN             15                          // EXP2 PB15
 #if SAFETY_DOOR_ENABLE
 #define SAFETY_DOOR_PORT            GPIOG
 #define SAFETY_DOOR_PIN             6                           // EXP1 PG4

--- a/platformio.ini
+++ b/platformio.ini
@@ -103,7 +103,7 @@ build_flags = ${common.build_flags}
   # See Inc/my_machine.h for options
   -D BOARD_BTT_SKR_PRO_1_1=
   # 8MHz crystal
-  -D HSE_VALUE=25000000
+  -D HSE_VALUE=8000000
   # Boot loader offset (32K)
   -D VECT_TAB_OFFSET=0x8000
 lib_deps = ${common.lib_deps}

--- a/platformio.ini
+++ b/platformio.ini
@@ -98,14 +98,13 @@ lib_ldf_mode = off
 # Untested and might not boot.  Please report issues at:
 # https://github.com/grblHAL/STM32F4xx/issues
 board = genericSTM32F407VGT6
-board_build.ldscript = STM32F407VGTX_FLASH.ld
+board_build.ldscript = STM32F407VGTX_BL32K_FLASH.ld
 build_flags = ${common.build_flags}
   # See Inc/my_machine.h for options
   -D BOARD_BTT_SKR_PRO_1_1=
   # 8MHz crystal
   -D HSE_VALUE=8000000
-  # Boot loader offset (32K)
-  -D VECT_TAB_OFFSET=0x8000
+  -D HAS_BOOTLOADER
 lib_deps = ${common.lib_deps}
   eeprom
 lib_extra_dirs = ${common.lib_extra_dirs}

--- a/platformio.ini
+++ b/platformio.ini
@@ -105,6 +105,7 @@ build_flags = ${common.build_flags}
   # 8MHz crystal
   -D HSE_VALUE=8000000
   -D HAS_BOOTLOADER
+  -D USB_SERIAL_CDC=1
 lib_deps = ${common.lib_deps}
   eeprom
 lib_extra_dirs = ${common.lib_extra_dirs}


### PR DESCRIPTION
Fixed clock speed for board
Configured to allow using the bootloader so can flash using sd card
Enable the usb serial port

Fix E0 and E1 limit pins mapping. Based off https://github.com/bigtreetech/BIGTREETECH-SKR-PRO-V1.1/blob/master/manual/SKR-PRO-V1.1-Pin.pdf

Moved the reset, feed hold, and cycle start pins to EXP2 port to avoid conflicting with the limit pins mapped when axes are ganged.

Have tested by compiling the firmware and flashing skr pro 1.2 board using sd card.

Added the pio build output folder to .gitignore