### PR TITLE
fix: hal.enumerate_pins function and callback signature

### DIFF
--- a/Src/btt_skr_1.1.c
+++ b/Src/btt_skr_1.1.c
@@ -128,7 +128,7 @@ TMC_spi_status_t tmc_spi_write (trinamic_motor_t driver, TMC_spi_datagram_t *dat
     return status;
 }
 
-static void add_cs_pin (xbar_t *gpio)
+static void add_cs_pin (xbar_t *gpio, void *data)
 {
     if (gpio->group == PinGroup_MotorChipSelect)
       switch (gpio->function) {
@@ -217,7 +217,7 @@ static void if_init (uint8_t motors, axes_signals_t enabled)
         hal.periph_port.register_pin(&sck);
         hal.periph_port.register_pin(&sdo);
         hal.periph_port.register_pin(&sdi);
-        hal.enumerate_pins(true, add_cs_pin);
+        hal.enumerate_pins(true, add_cs_pin, NULL);
     }
 }
 

--- a/Src/btt_skr_2.0.c
+++ b/Src/btt_skr_2.0.c
@@ -126,7 +126,7 @@ TMC_spi_status_t tmc_spi_write (trinamic_motor_t driver, TMC_spi_datagram_t *dat
   return status;
 }
 
-static void add_cs_pin (xbar_t *gpio)
+static void add_cs_pin (xbar_t *gpio, void *data)
 {
   if (gpio->group == PinGroup_MotorChipSelect) {
     switch (gpio->function) {
@@ -189,7 +189,7 @@ static void if_init(uint8_t motors, axes_signals_t enabled)
     GPIO_InitStruct.Pull = GPIO_PULLUP;
     HAL_GPIO_Init(TRINAMIC_MISO_PORT, &GPIO_InitStruct);
 
-    hal.enumerate_pins(true, add_cs_pin);
+    hal.enumerate_pins(true, add_cs_pin, NULL);
   }
 }
 

--- a/Src/st_morpho.c
+++ b/Src/st_morpho.c
@@ -143,7 +143,7 @@ TMC_spi_status_t tmc_spi_write (trinamic_motor_t driver, TMC_spi_datagram_t *reg
     return status;
 }
 
-static void add_cs_pin (xbar_t *gpio)
+static void add_cs_pin (xbar_t *gpio, void *data)
 {
     if(gpio->function == Output_MotorChipSelect) {
         cs.pin = gpio->pin;
@@ -154,7 +154,7 @@ static void add_cs_pin (xbar_t *gpio)
 static void if_init (uint8_t motors, axes_signals_t axisflags)
 {
     n_motors = motors;
-    hal.enumerate_pins(true, add_cs_pin);
+    hal.enumerate_pins(true, add_cs_pin, NULL);
 }
 
 #endif

--- a/Src/tmc_uart.c
+++ b/Src/tmc_uart.c
@@ -293,7 +293,7 @@ void tmc_uart_write (trinamic_motor_t driver, TMC_uart_write_datagram_t *dgr)
     write_n(dgr->data, sizeof(TMC_uart_write_datagram_t));
 }
 
-static void add_uart_pin (xbar_t *gpio)
+static void add_uart_pin (xbar_t *gpio, void *data)
 {
     if (gpio->group == PinGroup_MotorUART)
       switch (gpio->function) {
@@ -362,7 +362,7 @@ static void if_init (uint8_t motors, axes_signals_t enabled)
         HAL_NVIC_SetPriority(TMC_UART_IRQn, 0, 0);
         HAL_NVIC_EnableIRQ(TMC_UART_IRQn);
 
-        hal.enumerate_pins(true, add_uart_pin);
+        hal.enumerate_pins(true, add_uart_pin, NULL);
     }
 }
 


### PR DESCRIPTION
I am currently working on getting the driver to work on my SKR Pro v1.2 board.

During my development, I notices that the following commit changed the signature of `hal.enumerate_pins`: https://github.com/grblHAL/core/commit/180f9fa9fcf258c2c09de21ea61b2ffb207a5d02

This PR updates the driver to the new function signature