### PR TITLE
Since command to gain/Release control added to grblHAL, no sense to use TX line for it

### DIFF
--- a/boards/Devtronic_CNC_Controller.c
+++ b/boards/Devtronic_CNC_Controller.c
@@ -21,7 +21,7 @@
 
 #include "driver.h"
 
-#if defined(BOARD_DEVTRONIC_CNC)
+#if defined(BOARD_DEVTRONIC_CNC) && defined(HAS_BOARD_INIT)
 
 static xbar_t rx_pin;
 static on_execute_realtime_ptr on_execute_realtime, on_execute_delay;

--- a/boards/Devtronic_CNC_Controller_map.h
+++ b/boards/Devtronic_CNC_Controller_map.h
@@ -60,7 +60,7 @@
 #define BOARD_NAME "Devtronic CNC Controller"
 #endif
 
-#define HAS_BOARD_INIT
+//#define HAS_BOARD_INIT
 
 #define SERIAL_PORT 1   // GPIOA: TX = 9, RX = 10
 #define I2C_PORT    1   // GPIOB: SCL = 8, SDA = 9

--- a/driver.json
+++ b/driver.json
@@ -63,9 +63,8 @@
         "eeprom": 16,
         "fram": 1,
         "i2c": 1,
-        "i2c_strobe": 1,
         "spindle_sync": 1,
-        "keypad": 1,
+        "mpg_mode": 2,
         "pio_board": "blackpill_f411ce",
         "ldscript": "STM32F411CEUX_FLASH.ld"
       },


### PR DESCRIPTION
In fact to use TX line to switch control is was bad idea, when I ask to implement it I didn't realize that there some real time commands that can be send from MPG even if it is not in control(_Cycle Start/Hold/Stop for example_). Ability to sent those when sender stream g-code program is very useful. Since grblHAL incorporate CMD_MPG_MODE_TOGGLE in core without any plugins, it make sense to use it.
This merge request disables code to use UART TX line as control request, it also added "mpg_mode": 2 into driver.json, which hopefully will enable it in Web Builder.