### PR TITLE
Updated the platformio.ini to compile SKR2

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -41,10 +41,21 @@ src_dir = Src
 [common]
 build_flags =
   -I .
+  -I boards
   -I FatFs
+  -I FatFs/STM
+  -I Drivers/FATFS/Target
+  -I Middlewares/ST/STM32_USB_Device_Library/Class/CDC/Inc
+  -I Middlewares/ST/STM32_USB_Device_Library/Core/Inc
+  -I USB_DEVICE/App
   -I Middlewares/ST/STM32_USB_Device_Library/Class/CDC/Inc
   -I Middlewares/ST/STM32_USB_Device_Library/Core/Inc
   -I USB_DEVICE/Target
+  -D _USE_IOCTL=1
+  -D _USE_WRITE=1
+  -D _VOLUMES=1 
+  -Wl,-u,_printf_float
+  -Wl,-u,_scanf_float
   # Ignore all settings in Inc/my_machine.h (and instead use the below build flags)
   -D OVERRIDE_MY_MACHINE
   # Uncomment to enable debug builds
@@ -59,12 +70,24 @@ build_flags =
   # Set to 1 or 2 (see Inc/my_machine.h)
   #-D SPINDLE_HUANYANG=1
 lib_deps =
+  boards
   bluetooth
   grbl
   keypad
   laser
   motors
+  trinamic
   odometer
+  fans
+  spindle
+  embroidery
+  Drivers/FATFS/App
+  Drivers/FATFS/Target
+  # USB serial support
+  Middlewares/ST/STM32_USB_Device_Library/Core
+  Middlewares/ST/STM32_USB_Device_Library/Class
+  USB_DEVICE/App
+  USB_DEVICE/Target
 # To enable support for SD card, you must grab a copy FatFS:
 #   curl -O http://elm-chan.org/fsw/ff/arc/ff14b.zip
 #   unzip ff14b.zip 'source/*'
@@ -72,19 +95,29 @@ lib_deps =
 #   rm -fr ff14b.zip source FatFS/diskio.c
 # Next, apply the changes outlined in FatFS/README.md and then
 # uncomment `FatFS` and `sdcard` below.
-  #FatFs
-  #sdcard
-  spindle
+  FatFs
+  sdcard
   # USB serial support
-  Core
-  Class
-  App
-  Target
+#  Core
+#  Class
+#  App
+#  Target
 lib_extra_dirs =
   .
+  boards
   FatFs
   Middlewares/ST/STM32_USB_Device_Library
   USB_DEVICE
+
+[eth_networking]
+build_flags =
+  -I lwip/src/include
+  -I networking/wiznet
+lib_deps =
+   lwip
+   networking
+lib_extra_dirs =
+
 
 [env]
 platform = ststm32
@@ -117,20 +150,27 @@ lib_extra_dirs = ${common.lib_extra_dirs}
 # Untested and might not boot.  Please report issues at:
 # https://github.com/grblHAL/STM32F4xx/issues
 board = genericSTM32F407VGT6
-board_build.ldscript = STM32F407VGTX_FLASH.ld
+board_build.ldscript = STM32F407VGTX_BL32K_FLASH.ld
 build_flags = ${common.build_flags}
-  # See Inc/my_machine.h for options
-  -D BOARD_BTT_SKR_20=
+  -D WEB_BUILD
+  -D BOARD_BTT_SKR_20
+  -D USE_HAL_DRIVER
+  -D STM32F407xx
   -D HSE_VALUE=8000000
   -D USB_SERIAL_CDC=1
-  # Boot loader offset (32K)
-  -D VECT_TAB_OFFSET=0x8000
-  # TMC2130 stepper drivers
+  -D PROBE_ENABLE=1
   -D TRINAMIC_ENABLE=2130
+  -D TRINAMIC_UART_ENABLE=0
+  -D BLUETOOTH_ENABLE=0
+  -D NETWORKING_ENABLE=0
+  -D ESTOP_ENABLE=1
+  -D SPINDLE0_ENABLE=11
+  -D N_SPINDLE=1
 lib_deps = ${common.lib_deps}
   eeprom
-  trinamic
+
 lib_extra_dirs = ${common.lib_extra_dirs}
+
 # Upload is not supported for this board since BOOT0 is tied to GND.
 # With the default boot loader, you must deploy new firmware by copying
 # .pio/build/<env name>/firmware.bin (produced by `pio run`) to the SD card.
@@ -139,23 +179,61 @@ lib_extra_dirs = ${common.lib_extra_dirs}
 # Untested and might not boot.  Please report issues at:
 # https://github.com/grblHAL/STM32F4xx/issues
 board = genericSTM32F407VGT6
-board_build.ldscript = STM32F407VGTX_FLASH.ld
+board_build.ldscript = STM32F407VGTX_BL32K_FLASH.ld
 build_flags = ${common.build_flags}
-  # See Inc/my_machine.h for options
-  -D BOARD_BTT_SKR_20=
+  -D WEB_BUILD
+  -D BOARD_BTT_SKR_20
+  -D USE_HAL_DRIVER
+  -D STM32F407xx
   -D HSE_VALUE=8000000
   -D USB_SERIAL_CDC=1
-  # Boot loader offset (32K)
-  -D VECT_TAB_OFFSET=0x8000
-  # TMC5160 stepper drivers
+  -D PROBE_ENABLE=1
   -D TRINAMIC_ENABLE=5160
+  -D TRINAMIC_UART_ENABLE=0
+  -D BLUETOOTH_ENABLE=0
+  -D NETWORKING_ENABLE=0
+  -D ESTOP_ENABLE=1
+  -D SPINDLE0_ENABLE=11
+  -D N_SPINDLE=1
+
 lib_deps = ${common.lib_deps}
   eeprom
-  trinamic
+
 lib_extra_dirs = ${common.lib_extra_dirs}
+
 # Upload is not supported for this board since BOOT0 is tied to GND.
 # With the default boot loader, you must deploy new firmware by copying
 # .pio/build/<env name>/firmware.bin (produced by `pio run`) to the SD card.
+
+[env:btt_skr_2_tmc2209]
+# Untested and might not boot.  Please report issues at:
+# https://github.com/grblHAL/STM32F4xx/issues
+board = genericSTM32F407VGT6
+board_build.ldscript = STM32F407VGTX_BL32K_FLASH.ld
+build_flags = ${common.build_flags}
+  -D WEB_BUILD
+  -D BOARD_BTT_SKR_20
+  -D USE_HAL_DRIVER
+  -D STM32F407xx
+  -D HSE_VALUE=8000000
+  -D USB_SERIAL_CDC=1
+  -D PROBE_ENABLE=1
+  -D TRINAMIC_ENABLE=2209
+  -D TRINAMIC_UART_ENABLE=2
+  -D BLUETOOTH_ENABLE=0
+  -D NETWORKING_ENABLE=0
+  -D ESTOP_ENABLE=1
+  -D SPINDLE0_ENABLE=11
+  -D N_SPINDLE=1
+lib_deps = ${common.lib_deps}
+  eeprom
+
+lib_extra_dirs = ${common.lib_extra_dirs}
+
+# Upload is not supported for this board since BOOT0 is tied to GND.
+# With the default boot loader, you must deploy new firmware by copying
+# .pio/build/<env name>/firmware.bin (produced by `pio run`) to the SD card.
+
 
 [env:fysetc_s6]
 board = fysetc_s6


### PR DESCRIPTION
The default settings in the repository's platformio.ini fail to compile on a fresh platformio core installation (see #181 ).

Something in the default includes seems to be missing/incorrect. I am also providing an environment for TMC2209 drivers to work on the SKR2, since the `-DTRINAMC_ENABLE_UART=2` is not trivial to find in the documentation.

These defaults may be overzealous, but they do compile for SKR2. I will provide test results of the resulting firmware in 24 hours.