### PR TITLE
fmpi2c fix

### DIFF
--- a/Src/i2c.c
+++ b/Src/i2c.c
@@ -258,7 +258,11 @@ i2c_cap_t i2c_start (void)
 
 static inline __attribute__((always_inline)) bool wait_ready (void)
 {
+#ifdef I2C_FASTMODE
+    while(i2c_port.State != I2C_STATE_READY && __HAL_FMPI2C_GET_FLAG(&i2c_port, I2C_FLAG_BUSY) != RESET) {
+#else
     while(i2c_port.State != I2C_STATE_READY && __HAL_I2C_GET_FLAG(&i2c_port, I2C_FLAG_BUSY) != RESET) {
+#endif
         if(!hal.stream_blocking_callback())
             return false;
     }


### PR DESCRIPTION
It seems the recent changes to **i2c.c** might require an if/else guard to be compatible with i2c fastmode