### PR TITLE
Longboard - allow compile-time definition to swap probe and TLS pins

### DIFF
--- a/boards/longboard32_map.h
+++ b/boards/longboard32_map.h
@@ -377,6 +377,8 @@
 #endif
 
 // Define probe switch input pin.
+// If LONGBOARD_PROBESWAP is defined, then we swap the probe and toolsetter pins.
+// If undefined, the default behavior is used. Also note longboard32.c has custom code that will MUX tls/probe inputs depending on enabled features.
 #if defined(LONGBOARD_PROBESWAP)
   #if PROBE_ENABLE
   #define PROBE_PORT              AUXINPUT3_PORT


### PR DESCRIPTION
Hello! Would you be willing to consider this?

As it stands, the change should have *no effect* on any current builds (nor web builder).

However, if compiling locally, it would allow specifying a parameter to swap probes definitions. This will allow me to build firmware locally without requiring a separate/custom map file.

As the SLBEXT is a bit of a "commercial" product, the ports on the physical case are fixed as
- Probe, 2-pin header
- TLS, 3-pin header

The firmware currently reflects the naming as such.

For myself, and probably many, the inverse is more useful.
- Probe - 3-pin header to provide power to the popular 3D touch probe
- TLS, 2-pin header for a simple NC TLS

Having these inputs named appropriately is a better experience, and also plays nicer with grblHal options like "Auto select toolsetter"

This seems to be the least intrusive way for those who want 2 probes defined and using two MCU pins, as I longboard32.c will do some fun stuff in certain cases which probably covers Sienci's needs and simplifies support.