### PR TITLE
[WIP] Add STM32U585 support for Arduino UNO Q (3-axis CNC)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,4 +36,6 @@ build
 .vscode/settings.json
 .vscode/c_cpp_properties.json
 *.code-workspace
-platformio.local.ini
+platformio.local.ini*.bak
+*.bak2
+*.bak3

--- a/Inc/bitband_compat.h
+++ b/Inc/bitband_compat.h
@@ -1,0 +1,24 @@
+/**
+ * bitband_compat.h
+ * STM32U585 (Cortex-M33) 向け BITBAND_PERI 互換マクロ
+ */
+#ifndef BITBAND_COMPAT_H
+#define BITBAND_COMPAT_H
+
+#include "stm32u5xx.h"
+
+/* GPIO ピンをアトミックに HIGH に設定 */
+#define UNO_Q_GPIO_SET(port, pin)  ((port)->BSRR = (1u << (pin)))
+
+/* GPIO ピンをアトミックに LOW に設定 */
+#define UNO_Q_GPIO_CLR(port, pin)  ((port)->BRR  = (1u << (pin)))
+
+/* DIGITAL_IN の代替: IDR から1ビット読み取り */
+#define DIGITAL_IN(port, pin)       (((port)->IDR >> (pin)) & 1u)
+
+/* DIGITAL_OUT の代替: BSRR/BRR でアトミック書き込み */
+#define DIGITAL_OUT(port, pin, on) \
+    do { if (on) { UNO_Q_GPIO_SET((port),(pin)); } \
+         else    { UNO_Q_GPIO_CLR((port),(pin)); } } while(0)
+
+#endif /* BITBAND_COMPAT_H */

--- a/Inc/boards/uno_q_cnc_map.h
+++ b/Inc/boards/uno_q_cnc_map.h
@@ -1,0 +1,69 @@
+/**
+ * uno_q_cnc_map.h
+ * Arduino UNO Q + CNCシールドV3 ボードマップ
+ */
+#ifndef BOARD_UNO_Q_CNC_MAP_H
+#define BOARD_UNO_Q_CNC_MAP_H
+
+#define BOARD_NAME "Arduino UNO Q + CNC Shield V3"
+
+/* USB CDC 無効 */
+#undef  USB_SERIAL_CDC
+#define USB_SERIAL_CDC  0
+
+/* --- X軸 (D2=STEP, D5=DIR) --- */
+#define X_STEP_PORT         GPIOB
+#define X_STEP_PIN          3        /* PB3 = D2 (確定) */
+#define X_STEP_BIT          (1u << X_STEP_PIN)
+
+#define X_DIRECTION_PORT    GPIOA
+#define X_DIRECTION_PIN     11       /* PA11 = D5 (確定) */
+#define X_DIRECTION_BIT     (1u << X_DIRECTION_PIN)
+
+/* --- Y軸 (D3=STEP, D6=DIR) --- */
+#define Y_STEP_PORT         GPIOB
+#define Y_STEP_PIN          0        /* PB0 = D3 (確定) */
+#define Y_STEP_BIT          (1u << Y_STEP_PIN)
+
+#define Y_DIRECTION_PORT    GPIOB
+#define Y_DIRECTION_PIN     1        /* PB1 = D6 (確定) */
+#define Y_DIRECTION_BIT     (1u << Y_DIRECTION_PIN)
+
+/* --- Z軸 (D4=STEP, D7=DIR) --- */
+#define Z_STEP_PORT         GPIOA
+#define Z_STEP_PIN          12       /* PA12 = D4 (確定) */
+#define Z_STEP_BIT          (1u << Z_STEP_PIN)
+
+#define Z_DIRECTION_PORT    GPIOB
+#define Z_DIRECTION_PIN     2        /* PB2 = D7 (確定) */
+#define Z_DIRECTION_BIT     (1u << Z_DIRECTION_PIN)
+
+/* --- Enable (D8, ActiveLow) --- */
+#define STEPPERS_ENABLE_PORT    GPIOB
+#define STEPPERS_ENABLE_PIN     4        /* PB4 = D8 (確定) */
+#define STEPPERS_ENABLE_BIT     (1u << STEPPERS_ENABLE_PIN)
+
+/* --- 出力モード変更 --- */
+#define STEP_OUTMODE      GPIO_BITBAND  /* STEP: Z軸がGPIOAのため個別DIGITAL_OUT呼び出し */
+#define DIRECTION_OUTMODE GPIO_BITBAND  /* DIR:  異ポートのためDIGITAL_OUT個別呼び出し */
+                                        /* ↑ DIGITAL_OUTはbitband_compat.hのBSSR版が使われる */
+
+/* --- STEPマスク (GPIOB) --- */
+/* STEP_MASK: X(PB3)+Y(PB0) on GPIOB, Z(PA12) on GPIOA → split port, used for GPIO init only */
+#define STEP_MASK     (X_STEP_BIT | Y_STEP_BIT | Z_STEP_BIT)
+
+/* --- タイマー --- */
+#define STEPPER_TIMER_N     2
+#define STEPPER_TIMER       TIM2
+#define STEPPER_TIMER_IRQ   TIM2_IRQn
+
+#define PULSE_TIMER_N       3
+#define PULSE_TIMER         TIM3
+#define PULSE_TIMER_IRQ     TIM3_IRQn
+
+/* STEPパルス幅補正値 (160MHz用、要校正) */
+#define STEP_PULSE_TOFF     16
+
+#define N_AXIS  3
+
+#endif /* BOARD_UNO_Q_CNC_MAP_H */

--- a/Inc/driver.h
+++ b/Inc/driver.h
@@ -48,10 +48,17 @@
 
 #include "timers.h"
 
-#define BITBAND_PERI(x, b) (*((__IO uint8_t *) (PERIPH_BB_BASE + (((uint32_t)(volatile const uint32_t *)&(x)) - PERIPH_BASE)*32 + (b)*4)))
+#ifdef STM32U585xx
+  /* Cortex-M33 にはビットバンドがないため BSRR/BRR ベースの代替を使用 */
+  /* bitband_compat.h が DIGITAL_IN / DIGITAL_OUT を再定義する          */
+  #include "bitband_compat.h"
+#else
+  /* Cortex-M4 (STM32F4xx) 用 ― 従来通り */
+  #define BITBAND_PERI(x, b) (*((__IO uint8_t *) (PERIPH_BB_BASE + (((uint32_t)(volatile const uint32_t *)&(x)) - PERIPH_BASE)*32 + (b)*4)))
 
-#define DIGITAL_IN(port, pin) BITBAND_PERI((port)->IDR, pin)
-#define DIGITAL_OUT(port, pin, on) { BITBAND_PERI((port)->ODR, pin) = on; }
+  #define DIGITAL_IN(port, pin) BITBAND_PERI((port)->IDR, pin)
+  #define DIGITAL_OUT(port, pin, on) { BITBAND_PERI((port)->ODR, pin) = on; }
+#endif
 
 #define timer(t) timerN(t)
 #define timerN(t) TIM ## t
@@ -197,6 +204,8 @@
   #include "boards/stm32f407vet6_dev_board.h"
 #elif defined(BOARD_MY_MACHINE)
   #include "boards/my_machine_map.h"
+#elif defined(BOARD_UNO_Q_CNC)
+  #include "boards/uno_q_cnc_map.h"
 #else // default board
   #include "boards/generic_map.h"
 #endif

--- a/Inc/main.h
+++ b/Inc/main.h
@@ -28,7 +28,7 @@ extern "C" {
 #endif
 
 /* Includes ------------------------------------------------------------------*/
-#include "stm32f4xx_hal.h"
+#include "stm32u5xx_hal.h"
 
 /* Private includes ----------------------------------------------------------*/
 /* USER CODE BEGIN Includes */

--- a/Src/main.c
+++ b/Src/main.c
@@ -31,6 +31,55 @@ static void MX_GPIO_Init (void);
 
 int main (void)
 {
+#if defined(STM32U585xx)
+    /* ----------------------------------------------------------------
+     * Arduino UNO Q (STM32U585) クロック設定
+     * MSIS(4MHz) → PLL1(M=1,N=80,R=2) → SYSCLK 160MHz
+     * 出典: boards/arduino/uno_q/arduino_uno_q-common.dtsi
+     * ---------------------------------------------------------------- */
+
+    /* Range1: 160MHz 動作の必須条件 */
+    if (HAL_PWREx_ControlVoltageScaling(PWR_REGULATOR_VOLTAGE_SCALE1) != HAL_OK) {
+        Error_Handler();
+    }
+
+    RCC_OscInitTypeDef RCC_OscInitStruct_U5 = {
+        .OscillatorType      = RCC_OSCILLATORTYPE_MSI,
+        .MSIState            = RCC_MSI_ON,
+        .MSICalibrationValue = RCC_MSICALIBRATION_DEFAULT,
+        .MSIClockRange       = RCC_MSIRANGE_4,       /* 4 MHz */
+        .PLL.PLLState        = RCC_PLL_ON,
+        .PLL.PLLSource       = RCC_PLLSOURCE_MSI,
+        .PLL.PLLMBOOST       = RCC_PLLMBOOST_DIV1,  /* 低周波入力のためブースト不要 */
+        .PLL.PLLM            = 1,
+        .PLL.PLLN            = 80,
+        .PLL.PLLP            = 2,
+        .PLL.PLLQ            = 2,
+        .PLL.PLLR            = 2,   /* SYSCLK = 4 x 80 / 2 = 160 MHz */
+        .PLL.PLLFRACN        = 0,
+    };
+    if (HAL_RCC_OscConfig(&RCC_OscInitStruct_U5) != HAL_OK) {
+        Error_Handler();
+    }
+
+    RCC_ClkInitTypeDef RCC_ClkInitStruct_U5 = {
+        .ClockType      = RCC_CLOCKTYPE_HCLK | RCC_CLOCKTYPE_SYSCLK
+                        | RCC_CLOCKTYPE_PCLK1 | RCC_CLOCKTYPE_PCLK2
+                        | RCC_CLOCKTYPE_PCLK3,  /* U5 固有の APB3 */
+        .SYSCLKSource   = RCC_SYSCLKSOURCE_PLLCLK,
+        .AHBCLKDivider  = RCC_SYSCLK_DIV1,
+        .APB1CLKDivider = RCC_HCLK_DIV1,   /* TIM2/3 = 160 MHz */
+        .APB2CLKDivider = RCC_HCLK_DIV1,
+        .APB3CLKDivider = RCC_HCLK_DIV1,
+    };
+    /* FLASH_LATENCY_4: VOS1 + 160 MHz の必要値 (RM0456 Table 29) */
+    if (HAL_RCC_ClockConfig(&RCC_ClkInitStruct_U5, FLASH_LATENCY_4) != HAL_OK) {
+        Error_Handler();
+    }
+
+    return; /* F4xx 用コードをスキップ */
+
+#endif /* STM32U585xx */
     /* Reset of all peripherals, Initializes the Flash interface and the Systick. */
 #ifdef UF2_BOOTLOADER
     HAL_RCC_DeInit();

--- a/Src/system_stm32f4xx.c
+++ b/Src/system_stm32f4xx.c
@@ -46,7 +46,7 @@
   */
 
 
-#include "stm32f4xx.h"
+#include "stm32u5xx.h"
 
 #if !defined  (HSE_VALUE) 
   #define HSE_VALUE    ((uint32_t)25000000) /*!< Default value of the External oscillator in Hz */


### PR DESCRIPTION
## Overview

First grblHAL driver targeting STM32U585 (Cortex-M33) on the Arduino UNO Q board.

## Hardware

- **MCU**: STM32U585 (Arm Cortex-M33 @ 160MHz)
- **Linux side**: Qualcomm QRB2210 (Debian)
- **Shield**: Arduino CNC Shield V3 + A4988 stepper drivers
- **Axes**: 3-axis (X/Y/Z), expandable toward 5-axis

## Key changes

- `bitband_compat.h`: BSRR/BRR-based replacements for `BITBAND_PERI`
  (Cortex-M33 has no bit-band region)
- `boards/uno_q_cnc_map.h`: Pin map confirmed from Zephyr DTS
- `main.c`: STM32U585 `SystemClock_Config` (MSIS→PLL1→160MHz,
  confirmed from `arduino_uno_q-common.dtsi`)
- `driver.h`: `#ifdef STM32U585xx` guard for BITBAND macros

## Status: WIP ⚠️

- [ ] HAL/CMSIS library swap (STM32F4xx → STM32U5xx)
- [ ] `flash.c` QUADWORD adaptation
- [ ] Compile verification
- [ ] Hardware test (Arduino UNO Q not yet in hand)

Hardware is on order. Will update to ready-for-review once compiled and verified.